### PR TITLE
Fixed mobile menu and added link to "IT:s eventkalender" 

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,4 +24,15 @@
 //= require_tree .
 //= require i18n/translations
 
-$(function(){ $(document).foundation(); });
+$(function(){
+
+$(document).foundation();
+
+var $menu = $('#site-menu');
+
+$('#main-nav-toggle').on('click', function() {
+	$menu.toggle();
+});
+
+
+});

--- a/app/assets/stylesheets/common/_buttons.scss
+++ b/app/assets/stylesheets/common/_buttons.scss
@@ -1,7 +1,7 @@
 /*	=BUTTONS
 ----------------------------------------------------------------------*/
 
-@mixin states($color, 
+@mixin states($color,
 		$hover: darken($color, 20%)) {
 
 	$bg: $color;
@@ -15,11 +15,11 @@
 	@include background(linear-gradient($color, $bgalt));
 	@include transition(text-shadow .15s ease-out);
 	@include box-shadow(
-		$border 0 3px 0, 
+		$border 0 3px 0,
 		inset rgba(#fff, .1) 0 1px 0,
 		inset rgba(#fff, .1) 0 -1px 0,
 		rgba(0,0,0, 0.2) 0 2px 8px);
-	
+
 	&:hover,
 	&:focus {
 		outline: none;
@@ -29,12 +29,18 @@
 		@include background(linear-gradient(darken($color, 2%),
 			darken($bgalt, 3%)));
 	}
-	
+
 	&:active {
 		top: 1px;
 		@include box-shadow($border 0 2px 0);
 	}
 
+}
+
+.button.smaller {
+	padding: 10px 20px;
+	margin: 0;
+	font-size: 0.9rem;
 }
 
 // .btn,
@@ -51,10 +57,10 @@
 // 	color: #fff;
 // 	font: bold 1em/1 $sans;
 // 	text-align: center;
-	
+
 // 	@include border-radius(.2em);
 // 	@include states($btn-color);
-	
+
 // 	&.large {
 // 		padding: .6em 1.5em;
 // 		font-size: to_em(20);
@@ -65,7 +71,7 @@
 // 		font-size: to_em(13);
 // 		padding: .4em 1em;
 // 	}
-	
+
 // 	&.wide {
 // 		@extend .btn.large;
 // 		width: 100%;

--- a/app/assets/stylesheets/partials/_calendar.scss
+++ b/app/assets/stylesheets/partials/_calendar.scss
@@ -15,7 +15,7 @@
 }
 .gce-qtip-content {
 	background-color: transparent !important;
-	
+
 	.gce-event-info {
 		border: 0;
 		background-color: #000;
@@ -47,6 +47,7 @@
 .widget .gce-widget-grid .gce-calendar {
 	$caption-height: 3em;
 	width: 100%;
+	margin-bottom: 10px;
 
 	abbr {
 		border: 0;

--- a/app/views/calendar/fetch.html.erb
+++ b/app/views/calendar/fetch.html.erb
@@ -6,3 +6,5 @@
             <%= calendar Configurable.calendar_url %>
         </div>
     <% end %>
+
+	<a class="button secondary smaller block" target="_blank" href="https://calendar.google.com/calendar/embed?src=a55ipd3o49n05cd2eebqo854qs@group.calendar.google.com"><i class="fa fa-calendar"></i> <%= t '.subscribe' %></a>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,12 +3,12 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    
+
     <!-- iOS Homescreen specials -->
   	<meta name="apple-mobile-web-app-title" content="Chalmers.it">
   	<meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-  	
+
   	<!-- Viewport setting -->
   	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=1, user-scalable=no" />
 
@@ -26,7 +26,7 @@
   <body class="<%= body_classes %>">
     <header role="banner">
       <div class="top-bar">
-        <div class="inner-bar">
+        <div class="inner-bar" id="site-menu">
           <div class="wrapper group">
               <h1>
                 <%= link_to root_path(locale: locale_or_nil), class: 'logo' do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,7 +211,7 @@ en:
   calendar:
     fetch:
       events: "Events"
-
+      subscribe: "Subscribe (Google Calendar)"
   date:
     abbr_day_names:
     - Sun

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -215,6 +215,7 @@ sv:
   calendar:
       fetch:
         events: "Evenemang"
+        subscribe: "Prenumerera (Google Kalender)"
   print:
     new:
       supported_file_types: Filtyper som stöds


### PR DESCRIPTION
Fixed so that the mobile menu hamburger link actually opens the mobile menu - how was this not an "issue" already?

Also closes #93:

<img width="359" alt="skarmavbild 2016-11-08 kl 19 36 42" src="https://cloud.githubusercontent.com/assets/1730738/20112629/6f1439a4-a5ed-11e6-80ca-d8941a931be1.png">
