### PR TITLE
Set flashes for printer controller to now

### DIFF
--- a/app/controllers/print_controller.rb
+++ b/app/controllers/print_controller.rb
@@ -25,11 +25,11 @@ class PrintController < ApplicationController
         print_script @print
         @print.printer.increment!(:weight)
         @print.file_cache = nil
-        flash[:notice] = "Your document has been sent to the printer"
+        flash.now[:notice] = "Your document has been sent to the printer"
       rescue => e
         # Log error message to log/printer.log
         @print.print_logger e.message
-        flash[:alert] = e.message
+        flash.now[:alert] = e.message
       end
     elsif @print.errors[:file].any?
       @print.file = nil


### PR DESCRIPTION
Makes them visible only to the current action, and removes them afterwards. So the next action will not see the previous :alert or :notice

fixes #103 