### PR TITLE
Style the sidebar of page and committee in the same way as chalmers.it

### DIFF
--- a/app/assets/stylesheets/common/_pages.scss
+++ b/app/assets/stylesheets/common/_pages.scss
@@ -50,6 +50,5 @@
 	}
 	.child {
 		margin-left: 15px;
-		margin-right: 15px;
 	}
 }

--- a/app/assets/stylesheets/common/_pages.scss
+++ b/app/assets/stylesheets/common/_pages.scss
@@ -25,6 +25,31 @@
 	color: #444;
 
 	p {
-		margin-bottom: $lineheight;		
+		margin-bottom: $lineheight;
+	}
+}
+
+.sidebar .left{
+	a:hover {
+		background-color: #eff6f7;
+		text-decoration: none;
+		color: #000;
+    font-weight: 500;
+	}
+	a {
+		color: #000;
+    font-weight: 500;
+		display: block;
+	}
+	hr {
+		margin: 2px;
+	}
+	p {
+		font-weight: 500;
+		color: #999;
+	}
+	.child {
+		margin-left: 15px;
+		margin-right: 15px;
 	}
 }

--- a/app/views/committees/show.html.erb
+++ b/app/views/committees/show.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: 'committees/sidebar' %>
 <% end %>
 <% content_for :sidebar_left do %>
-  <%= render partial: 'pages/sidebar' %>
+  <%= render partial: 'pages/sidebar', locals: {current_committee: @committee} %>
 <% end %>
 <% content_for :title, @committee.name %>
 <% content_for :subtitle, @committee.title %>

--- a/app/views/pages/_sidebar.html.erb
+++ b/app/views/pages/_sidebar.html.erb
@@ -4,7 +4,7 @@
 <div class="sidebar box left">
   <section>
     <h2><%= t("about_section") %></h2>
-    <% @pages.where(parent_id: nil).each do |page| %>
+    <% @pages.where(parent_id: nil).each do |parent_page| %>
       <% if current_page == parent_page %>
         <p><%= parent_page.title %></p>
       <% else %>

--- a/app/views/pages/_sidebar.html.erb
+++ b/app/views/pages/_sidebar.html.erb
@@ -4,11 +4,19 @@
 <div class="sidebar box left">
   <section>
     <h2><%= t("about_section") %></h2>
-    <% @pages.each do |page| %>
-      <% if current_page == page %>
-        <p><%= page.title %></p>
+    <% @pages.where(parent_id: nil).each do |page| %>
+      <% if current_page == parent_page %>
+        <p><%= parent_page.title %></p>
       <% else %>
-        <%= link_to page.title, path_to_page(page) %>
+        <%= link_to parent_page.title, path_to_page(parent_page) %>
+      <% end %>
+      <% @pages.where(parent_id: parent_page.id).each do |child_page| %>
+        <hr class="child">
+        <% if current_page == child_page %>
+          <p class="child"><%= child_page.title %></p>
+        <% else %>
+          <%= link_to child_page.title, path_to_page(child_page), class: "child"%>
+        <% end %>
       <% end %>
       <hr>
     <% end %>

--- a/app/views/pages/_sidebar.html.erb
+++ b/app/views/pages/_sidebar.html.erb
@@ -10,15 +10,15 @@
       <% else %>
         <%= link_to parent_page.title, path_to_page(parent_page) %>
       <% end %>
+      <hr>
       <% @pages.where(parent_id: parent_page.id).each do |child_page| %>
-        <hr class="child">
         <% if current_page == child_page %>
           <p class="child"><%= child_page.title %></p>
         <% else %>
           <%= link_to child_page.title, path_to_page(child_page), class: "child"%>
         <% end %>
+        <hr class="child">
       <% end %>
-      <hr>
     <% end %>
   </section>
 

--- a/app/views/pages/_sidebar.html.erb
+++ b/app/views/pages/_sidebar.html.erb
@@ -1,15 +1,28 @@
-<div class="sidebar box">
+<% current_committee = nil if local_assigns[:current_committee].nil? %>
+<% current_page = nil if local_assigns[:current_page].nil? %>
+
+<div class="sidebar box left">
   <section>
     <h2><%= t("about_section") %></h2>
     <% @pages.each do |page| %>
-      <p><%= link_to page.title, path_to_page(page) %></p>
+      <% if current_page == page %>
+        <p><%= page.title %></p>
+      <% else %>
+        <%= link_to page.title, path_to_page(page) %>
+      <% end %>
+      <hr>
     <% end %>
   </section>
 
   <section>
     <h2><%= t("committees_assoiciations") %> </h2>
     <% @committees.each do |committee| %>
-      <p><%= link_to committee.name, committee %></p>
+      <% if committee == current_committee %>
+        <p><%= committee.name %></p>
+      <% else %>
+        <%= link_to committee.name, committee %>
+      <% end %>
+      <hr>
     <% end %>
   </section>
 </div>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, @page.title %>
 <% content_for :sidebar_left do %>
-	<%= render partial: 'pages/sidebar' %>
+	<%= render partial: 'pages/sidebar', locals: {current_page: @page} %>
 <% end %>
 
 <%= markdown @page.body %>


### PR DESCRIPTION
Before/now:
![2016-11-19-124254_701x1205_scrot](https://cloud.githubusercontent.com/assets/2412457/20455193/2dc8cafc-ae56-11e6-9c05-218e1bf402c7.png)
![2016-11-19-124647_692x1359_scrot](https://cloud.githubusercontent.com/assets/2412457/20455200/439fef18-ae56-11e6-8a05-c99a70a10730.png)


The hierarchy of pages is only two levels deep visually at the moment(other pages are not displayed). Not sure if this will ever be an issue.

This bothered me.