### PR TITLE
Make sure event-meta does not overflow box

### DIFF
--- a/app/assets/stylesheets/partials/_posts.scss
+++ b/app/assets/stylesheets/partials/_posts.scss
@@ -117,17 +117,14 @@
 	width: 100%;
 	text-align: center;
 	font-size: to_em(16) !important;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
 
 	li {
 		display: table-cell;
 		border-right: 1px solid $border-color;
-		padding: .5em 0;
-
-		/* Don't grow too large .. */
-		max-width: 145px;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		padding: .5em .5em;
 
 		&:last-child {
 			border: 0;


### PR DESCRIPTION
Not sure about how good it looks, but at least does not overflow: 
Fixes #131 

Before mobile:
![2016-11-22-215759_931x415_scrot](https://cloud.githubusercontent.com/assets/2412457/20541745/c920ad3a-b0fe-11e6-95bf-5c2ccb3d002a.png)

After mobile:
![2016-11-22-215438_789x449_scrot](https://cloud.githubusercontent.com/assets/2412457/20541694/9029964a-b0fe-11e6-8c77-bab0fc773e8c.png)


Before full width:
![2016-11-22-215909_1437x336_scrot](https://cloud.githubusercontent.com/assets/2412457/20541794/efbf6f4e-b0fe-11e6-9406-76d4ce5f41f3.png)

After full width:
![2016-11-22-215426_1442x317_scrot](https://cloud.githubusercontent.com/assets/2412457/20541704/a0c6435e-b0fe-11e6-8e38-fd46bbc6736b.png)
