### PR TITLE
No longer overwrites the other locale when uploading a file 

### DIFF
--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -1,6 +1,9 @@
 image_exts = [".jpg", ".jpeg", ".gif", ".png", ".webp"]
 doc_exts = [".pdf", ".md", ".txt"]
-post_body = '.posts #post_body_en, .posts #post_body_sv, #page_body'
+post_body = '.posts #post_body_en, .posts #post_body_sv, #page_body, #page_body'
+en_post_body = '.posts #post_body_en, #page_body'
+sv_post_body = '.posts #post_body_sv, #page_body'
+
 $ ->
 
   $(post_body + ', #post_item_upload, #page_item_upload').fileupload
@@ -32,9 +35,11 @@ $ ->
       src = data.result.source
       extension = src.url.substr(src.url.lastIndexOf('.'), src.url.length)
       if $.inArray(extension, image_exts) > -1
-        insertTextAtCaret($(post_body), image_thumbnail_markdown(data.orig_name, src.url, src.thumb.url) + "\n")
+        insertTextAtCaret($(sv_post_body), image_thumbnail_markdown(data.orig_name, src.url, src.thumb.url) + "\n")
+        insertTextAtCaret($(en_post_body), image_thumbnail_markdown(data.orig_name, src.url, src.thumb.url) + "\n")
       else
-        insertTextAtCaret($(post_body), link_markdown(data.orig_name, src.url) + "\n")
+        insertTextAtCaret($(sv_post_body), link_markdown(data.orig_name, src.url) + "\n")
+        insertTextAtCaret($(en_post_body), link_markdown(data.orig_name, src.url) + "\n")
 
 handle_file_error = (data) ->
   data.label.text I18n.t('unsupported_file_format')

--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -1,8 +1,8 @@
 image_exts = [".jpg", ".jpeg", ".gif", ".png", ".webp"]
 doc_exts = [".pdf", ".md", ".txt"]
-post_body = '.posts #post_body_en, .posts #post_body_sv, #page_body, #page_body'
-en_post_body = '.posts #post_body_en, #page_body'
-sv_post_body = '.posts #post_body_sv, #page_body'
+post_body = '.posts #post_body_en, .posts #post_body_sv, #page_body_sv, #page_body_en'
+en_post_body = '.posts #post_body_en, #page_body_en'
+sv_post_body = '.posts #post_body_sv, #page_body_sv'
 
 $ ->
 

--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -6,7 +6,7 @@ sv_post_body = '.posts #post_body_sv, #page_body_sv'
 
 $ ->
 
-  $(post_body + ', #post_item_upload, #page_item_upload').fileupload
+  $(en_post_body + sv_post_body).fileupload
     url: '/uploads.json',
     paramName: 'upload[source]',
     add: (e, data) ->

--- a/app/views/posts/_localized_fields.html.erb
+++ b/app/views/posts/_localized_fields.html.erb
@@ -15,10 +15,7 @@
         </div>
         <div class="row">
           <div class="large-12 columns">
-            <%= f.input "body_#{locale}", as: :text, label: Post.human_attribute_name(:body), placeholder: t('posts.form.body_placeholder'), input_html: { rows: 20 } %>
-          </div>
-          <div class="large-12 columns image-upload-button">
-            <%= f.file_field :item_upload %>
+            <%= f.input "body_#{locale}", as: :text, label: Post.human_attribute_name(:body), placeholder: t('posts.form.body_placeholder'), input_html: { rows: 20 }, :class => "upload_listener" %>
           </div>
         </div>
         <button class="preview large-12 columns" data-text="#post_body_<%= locale %>" data-title="#post_title_<%= locale %>"><%= t 'preview' %></button>


### PR DESCRIPTION
Fixes #140 and enables uploading files to pages again.

I haven't actually been able to test this on posts (as I'm not currently set up to write posts), just assumed the post works the same as for pages.