### PR TITLE
Show all errors for pages and posts on top of form

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -43,6 +43,7 @@ class PagesController < ApplicationController
         format.html { redirect_to @page, notice: 'Page was successfully created.' }
         format.json { render :show, status: :created, location: @page }
       else
+        @other_pages = Page.all
         format.html { render :new }
         format.json { render json: @page.errors, status: :unprocessable_entity }
       end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -1,5 +1,5 @@
-<%= simple_form_for(@page) do |f| %>
-  <%= f.error_notification %>
+<%= simple_form_for(@page, html: { novalidate: true }) do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
 
   <%= render "localized_fields", f: f %>
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -28,8 +28,8 @@
 	</div>
 <% end %>
 
-<%= simple_form_for(@post) do |f| %>
-  <%= f.error_notification %>
+<%= simple_form_for(@post, html: { novalidate: true }) do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
 
   <div class="row">
     <div class="large-6 columns">

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+ <% if object.errors.any? %>
+  <div id="error_explanation" class="alert alert-box">
+   <div>
+     The form contains <%= pluralize(object.errors.count, "error") %>.
+   </div>
+  <ul>
+   <% object.errors.full_messages.each do |msg| %>
+    <li><%= msg %></li>
+   <% end %>
+ </ul>
+</div>
+<% end %>


### PR DESCRIPTION
Skipped html5 validations, which I'm not really happy about. But in the trade-off between not getting all errors, and having html5 validations, I believe getting all errors is more important. Haven't actually been able to test on posts, since I'm not able to create them, but works fine on pages. So please test on posts before merging.

Fixes #91 I believe

![https://kalior.keybase.pub/photos/2016-11-25-214939_1025x1503_scrot.png](https://kalior.keybase.pub/photos/2016-11-25-214939_1025x1503_scrot.png)
