### PR TITLE
Hides Menu, Menu Links, Frontpage, Committees index, 

### DIFF
--- a/app/controllers/committees_controller.rb
+++ b/app/controllers/committees_controller.rb
@@ -6,6 +6,7 @@ class CommitteesController < ApplicationController
   # GET /committees.json
   def index
     # Committees are loaded in ApplicationController
+    redirect_to '/committees/styrit'
   end
 
   # GET /committees/1

--- a/app/controllers/frontpage_controller.rb
+++ b/app/controllers/frontpage_controller.rb
@@ -4,20 +4,26 @@ class FrontpageController < ApplicationController
   def update
      @frontpage = Frontpage.first
      @frontpage.update(frontpage_params)
-     
+
      @pages = Page.all
      render :edit
+     authorize_frontpage
   end
 
   def edit
     @frontpage = Frontpage.first
     @pages = Page.all
+    authorize_frontpage
   end
 
   private
 
     def frontpage_params
       params.require(:frontpage).permit([:page_id])
+    end
+
+    def authorize_frontpage
+      authorize @frontpage
     end
 
 end

--- a/app/controllers/menu_links_controller.rb
+++ b/app/controllers/menu_links_controller.rb
@@ -1,10 +1,12 @@
 class MenuLinksController < ApplicationController
   before_action :set_menu_link, only: [:show, :edit, :update, :destroy]
+  before_action :authorize_menu_link, except: [:index, :create, :new]
 
   # GET /menu_links
   # GET /menu_links.json
   def index
     @menu_links = MenuLink.all
+    authorize @menu_links
   end
 
   # GET /menu_links/1
@@ -15,6 +17,7 @@ class MenuLinksController < ApplicationController
   # GET /menu_links/new
   def new
     @menu_link = MenuLink.new
+    authorize_menu_link
   end
 
   # GET /menu_links/1/edit
@@ -25,7 +28,7 @@ class MenuLinksController < ApplicationController
   # POST /menu_links.json
   def create
     @menu_link = MenuLink.new(menu_link_params)
-
+    authorize_menu_link
     respond_to do |format|
       if @menu_link.save
         format.html { redirect_to @menu_link, notice: 'Menu link was successfully created.' }
@@ -70,5 +73,9 @@ class MenuLinksController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def menu_link_params
       params.require(:menu_link).permit(:menu_id, :controller, :action, :params, :title)
+    end
+
+    def authorize_menu_link
+      authorize @menu_link
     end
 end

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,10 +1,12 @@
 class MenusController < ApplicationController
   before_action :set_menu, only: [:show, :edit, :update, :destroy]
+  before_action :authorize_menu, except: [:index, :create, :new]
 
   # GET /menus
   # GET /menus.json
   def index
     @menus = Menu.all
+    authorize @menus
   end
 
   # GET /menus/1
@@ -15,6 +17,7 @@ class MenusController < ApplicationController
   # GET /menus/new
   def new
     @menu = Menu.new
+    authorize_menu
   end
 
   # GET /menus/1/edit
@@ -25,6 +28,7 @@ class MenusController < ApplicationController
   # POST /menus.json
   def create
     @menu = Menu.new(menu_params)
+    authorize_menu
 
     respond_to do |format|
       if @menu.save
@@ -70,5 +74,9 @@ class MenusController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def menu_params
       params.require(:menu).permit(:name)
+    end
+
+    def authorize_menu
+      authorize @menu
     end
 end

--- a/app/policies/frontpage_policy.rb
+++ b/app/policies/frontpage_policy.rb
@@ -1,4 +1,4 @@
-class PagePolicy < ApplicationPolicy
+class FrontpagePolicy < ApplicationPolicy
 
   def show?
     super

--- a/app/policies/menu_link_policy.rb
+++ b/app/policies/menu_link_policy.rb
@@ -1,0 +1,10 @@
+class MenuLinkPolicy < ApplicationPolicy
+
+  def index?
+    create?
+  end
+
+  def show?
+    index?
+  end
+end

--- a/app/policies/menu_policy.rb
+++ b/app/policies/menu_policy.rb
@@ -1,0 +1,10 @@
+class MenuPolicy < ApplicationPolicy
+
+  def index?
+    create?
+  end
+
+  def show?
+    index?
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -72,16 +72,16 @@
                   <% if policy(Page).create? %>
                     <li><%= link_to t('.new_page'), new_page_path %></li>
                   <% end %>
-                  <% if policy(Frontpage).create? %>
+                  <% if policy(Frontpage).edit? %>
                     <li><%= link_to t('.edit_frontpage'), edit_frontpage_path %></li>
                   <% end %>
                   <% if policy(Committee).create? %>
                     <li><%= link_to t('.add_committee'), new_committee_path %></li>
                   <% end %>
-                  <% if policy(MenuLink).create? %>
+                  <% if policy(MenuLink).edit? %>
                     <li><%= link_to t('.edit_menu_links'), menu_links_path %></li>
                   <% end %>
-                  <% if policy(Menu).create? %>
+                  <% if policy(Menu).edit? %>
                     <li><%= link_to t('.edit_menu'), menus_path %></li>
                   <% end %>
                   <li><%= link_to t('.edit_profile'), edit_user_path %></li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -72,10 +72,19 @@
                   <% if policy(Page).create? %>
                     <li><%= link_to t('.new_page'), new_page_path %></li>
                   <% end %>
-                  <li><%= link_to t('.edit_profile'), edit_user_path %></li>
-                  <% if current_user.admin? %>
+                  <% if policy(Frontpage).create? %>
                     <li><%= link_to t('.edit_frontpage'), edit_frontpage_path %></li>
                   <% end %>
+                  <% if policy(Committee).create? %>
+                    <li><%= link_to t('.add_committee'), new_committee_path %></li>
+                  <% end %>
+                  <% if policy(MenuLink).create? %>
+                    <li><%= link_to t('.edit_menu_links'), menu_links_path %></li>
+                  <% end %>
+                  <% if policy(Menu).create? %>
+                    <li><%= link_to t('.edit_menu'), menus_path %></li>
+                  <% end %>
+                  <li><%= link_to t('.edit_profile'), edit_user_path %></li>
                   <li><%= link_to t('logout'), signout_path %></li>
                 </ul>
               </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,7 +159,10 @@ en:
       new_page: Add new page
       edit_profile: Edit profile
       admin: Admin
-      edit_frontpage: "Edit section frontpage"
+      edit_frontpage: Edit section frontpage
+      add_committee: Add new committee
+      edit_menu_links: Edit menu links
+      edit_menu: Edit menu
     home:
       booking: Booking
       group_room: Group room

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -174,7 +174,10 @@ sv:
       new_page: Lägg till ny sida
       edit_profile: Redigera profil
       admin: Admin
-      edit_frontpage: "Ändra sektionsida"
+      edit_frontpage: Ändra sektionsida
+      add_committee: Lägg till ny kommitté
+      edit_menu_links: Ändra menylänkar
+      edit_menu: Ändra meny
     home:
       booking: Bokning
       group_room: Grupprum


### PR DESCRIPTION
These views are now hidden from people who should not see them (and their corresponding actions have to be authorised), and committees index redirects to committees/styrit. Fixes #208 

Realised this also solves part of #202, only sponsors left.
