### PR TITLE
Move edit links to the right of title in page and committee

### DIFF
--- a/app/assets/stylesheets/common/_headings.scss
+++ b/app/assets/stylesheets/common/_headings.scss
@@ -102,3 +102,9 @@ h4 {
 h5 {
 
 }
+
+.title-with-buttons {
+	display: flex;
+	justify-content: space-between;
+	max-height: 5em;
+}

--- a/app/views/committees/show.html.erb
+++ b/app/views/committees/show.html.erb
@@ -11,6 +11,6 @@
   <%= markdown @committee.description unless @committee.description.nil? %>
 </p>
 <% if policy(@committee).update? %>
-  <%= link_to t('edit'), edit_committee_path(@committee) %> |
+  <% content_for :buttons, (link_to t('edit'), edit_committee_path(@committee), class: "button tiny") %>
 <% end %>
 <%= link_to t('back'), committees_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
 </aside>
 <section class="large-6 columns <%= 'large-offset-3' if !content_for?(:sidebar_left) && !content_for?(:sidebar_right) %>">
   <article class="box" role="article">
+    <div class="title-with-buttons">
     <% if content_for? :subtitle %>
       <hgroup class="page-title">
         <h1><%= yield(:title) %></h1>
@@ -12,6 +13,10 @@
     <% else %>
       <h1 class="huge"><%= yield(:title) %></h1>
     <% end %>
+      <div>
+        <%= yield(:buttons) %>
+      </div>
+    </div>
     <div class="article-content">
       <%= yield %>
     </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -12,6 +12,6 @@
     <%= link_to 'Parent', path_to_page(@frontpage.parent) %>
 <% end %>
 <% if policy(Page).update? %>
-  <%= link_to 'Edit', edit_page_path(@frontpage) %> |
+  <%= content_for :buttons, (link_to 'Edit', edit_page_path(@frontpage), class: "button tiny") %>
 <% end %>
 <%= link_to 'Back', pages_path %>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -10,6 +10,6 @@
     <%= link_to 'Parent', path_to_page(@page.parent) %>
 <% end %>
 <% if policy(Page).update? %>
-	<%= link_to 'Edit', edit_page_path(@page) %> |
+	<%= content_for :buttons, (link_to 'Edit', edit_page_path(@page), class: "button tiny") %>
 <% end %>
 <%= link_to 'Back', pages_path %>


### PR DESCRIPTION
I believe this fixes #188 as we don't have any other add/edits?
![image](https://cloud.githubusercontent.com/assets/2412457/21076361/a10d86f4-bf29-11e6-8f82-cc19bca279d5.png)
