### PR TITLE
Fixes up the forms for menus and menu_links

### DIFF
--- a/app/controllers/menu_links_controller.rb
+++ b/app/controllers/menu_links_controller.rb
@@ -72,7 +72,8 @@ class MenuLinksController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def menu_link_params
-      params.require(:menu_link).permit(:menu_id, :controller, :action, :params, :title)
+      permitted = [:menu_id, :controller, :action, :params, :title, :preferred_order]
+      params.require(:menu_link).permit(permitted)
     end
 
     def authorize_menu_link

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,7 +2,7 @@ class Menu < ActiveRecord::Base
   has_many :links, class_name: 'MenuLink'
 
   def self.links_for_menu_cached(menu_name)
-    Rails.cache.fetch(Menu.where(name: menu_name).last, expires_in: 24.hours) do
+    Rails.cache.fetch(Menu.where(name: menu_name).last.links) do
       Menu.where(name: menu_name).last.links.sort_by{|l| l.preferred_order}.to_a
     end
   end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,7 +2,7 @@ class Menu < ActiveRecord::Base
   has_many :links, class_name: 'MenuLink'
 
   def self.links_for_menu_cached(menu_name)
-    Rails.cache.fetch(Menu.where(name: menu_name).last.cache_key, expires_in: 24.hours) do
+    Rails.cache.fetch(Menu.where(name: menu_name).last, expires_in: 24.hours) do
       Menu.where(name: menu_name).last.links.sort_by{|l| l.preferred_order}.to_a
     end
   end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -3,7 +3,7 @@ class Menu < ActiveRecord::Base
 
   def self.links_for_menu_cached(menu_name)
     Rails.cache.fetch("menus/#{menu_name}") do
-      Menu.where(name: menu_name).last.links.to_a
+      Menu.where(name: menu_name).last.links.sort_by{|l| l.preferred_order}.to_a
     end
   end
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,7 +2,7 @@ class Menu < ActiveRecord::Base
   has_many :links, class_name: 'MenuLink'
 
   def self.links_for_menu_cached(menu_name)
-    Rails.cache.fetch(Menu.where(name: menu_name).last.links) do
+    Rails.cache.fetch(Menu.where(name: menu_name).last) do
       Menu.where(name: menu_name).last.links.sort_by{|l| l.preferred_order}.to_a
     end
   end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,7 +2,7 @@ class Menu < ActiveRecord::Base
   has_many :links, class_name: 'MenuLink'
 
   def self.links_for_menu_cached(menu_name)
-    Rails.cache.fetch("menus/#{menu_name}") do
+    Rails.cache.fetch("menus/#{menu_name}", expires_in: 24.hours) do
       Menu.where(name: menu_name).last.links.sort_by{|l| l.preferred_order}.to_a
     end
   end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,7 +2,7 @@ class Menu < ActiveRecord::Base
   has_many :links, class_name: 'MenuLink'
 
   def self.links_for_menu_cached(menu_name)
-    Rails.cache.fetch("menus/#{menu_name}", expires_in: 24.hours) do
+    Rails.cache.fetch(Menu.where(name: menu_name).last.cache_key, expires_in: 24.hours) do
       Menu.where(name: menu_name).last.links.sort_by{|l| l.preferred_order}.to_a
     end
   end

--- a/app/models/menu_link.rb
+++ b/app/models/menu_link.rb
@@ -1,5 +1,5 @@
 class MenuLink < ActiveRecord::Base
-  belongs_to :menu
+  belongs_to :menu, touch: true
   serialize :params, Hash
 
   def url_params

--- a/app/views/menu_links/_form.html.erb
+++ b/app/views/menu_links/_form.html.erb
@@ -1,37 +1,11 @@
-<%= form_for(@menu_link) do |f| %>
-  <% if @menu_link.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@menu_link.errors.count, "error") %> prohibited this menu_link from being saved:</h2>
+<%= simple_form_for(@menu_link) do |f| %>
+  <%= f.error_notification %>
 
-      <ul>
-      <% @menu_link.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= f.association :menu %>
+  <%= f.input :controller %>
+  <%= f.input :action %>
+  <%= f.input :title %>
+  <%= f.input :preferred_order %>
 
-  <div class="field">
-    <%= f.label :menu_id %><br>
-    <%= f.text_field :menu_id %>
-  </div>
-  <div class="field">
-    <%= f.label :controller %><br>
-    <%= f.text_field :controller %>
-  </div>
-  <div class="field">
-    <%= f.label :action %><br>
-    <%= f.text_field :action %>
-  </div>
-  <div class="field">
-    <%= f.label :params %><br>
-    <%= f.text_field :params %>
-  </div>
-  <div class="field">
-    <%= f.label :title %><br>
-    <%= f.text_field :title %>
-  </div>
-  <div class="actions">
-    <%= f.submit %>
-  </div>
+  <%= f.button :submit %>
 <% end %>

--- a/app/views/menu_links/index.html.erb
+++ b/app/views/menu_links/index.html.erb
@@ -26,5 +26,3 @@
 </table>
 
 <br>
-
-<%= link_to 'New Menu link', new_menu_link_path %>

--- a/app/views/menu_links/index.html.erb
+++ b/app/views/menu_links/index.html.erb
@@ -1,13 +1,12 @@
-<h1>Listing menu_links</h1>
+<%= content_for :title, "Menu links" %>
+<%= content_for :buttons, (link_to 'New Menu link', new_menu_link_path, class: "button tiny") %>
 
 <table>
   <thead>
     <tr>
-      <th>Menu</th>
+      <th>Title</th>
       <th>Controller</th>
       <th>Action</th>
-      <th>Params</th>
-      <th>Title</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -15,11 +14,9 @@
   <tbody>
     <% @menu_links.each do |menu_link| %>
       <tr>
-        <td><%= menu_link.menu %></td>
+        <td><%= menu_link.title %></td>
         <td><%= menu_link.controller %></td>
         <td><%= menu_link.action %></td>
-        <td><%= menu_link.params %></td>
-        <td><%= menu_link.title %></td>
         <td><%= link_to 'Show', menu_link %></td>
         <td><%= link_to 'Edit', edit_menu_link_path(menu_link) %></td>
         <td><%= link_to 'Destroy', menu_link, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/menu_links/show.html.erb
+++ b/app/views/menu_links/show.html.erb
@@ -1,9 +1,9 @@
+<%= content_for :title, (@menu_link.title + " menu link") %>
+<% content_for :buttons do %>
+  <%= link_to 'Edit', edit_menu_link_path(@menu_link), class: "button tiny" %>
+  <%= link_to 'Back', menu_links_path, class: "button tiny" %>
+<% end %>
 <p id="notice"><%= notice %></p>
-
-<p>
-  <strong>Menu:</strong>
-  <%= @menu_link.menu %>
-</p>
 
 <p>
   <strong>Controller:</strong>
@@ -14,16 +14,3 @@
   <strong>Action:</strong>
   <%= @menu_link.action %>
 </p>
-
-<p>
-  <strong>Params:</strong>
-  <%= @menu_link.params %>
-</p>
-
-<p>
-  <strong>Title:</strong>
-  <%= @menu_link.title %>
-</p>
-
-<%= link_to 'Edit', edit_menu_link_path(@menu_link) %> |
-<%= link_to 'Back', menu_links_path %>

--- a/app/views/menus/_form.html.erb
+++ b/app/views/menus/_form.html.erb
@@ -1,21 +1,7 @@
-<%= form_for(@menu) do |f| %>
-  <% if @menu.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@menu.errors.count, "error") %> prohibited this menu from being saved:</h2>
+<%= simple_form_for(@menu) do |f| %>
+  <%= f.error_notification %>
+  <%= f.label "In order to change the links of this menu, edit the links" %>
+  <%= f.input :name %>
 
-      <ul>
-      <% @menu.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :name %><br>
-    <%= f.text_field :name %>
-  </div>
-  <div class="actions">
-    <%= f.submit %>
-  </div>
+  <%= f.button :submit %>
 <% end %>

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -1,4 +1,5 @@
-<h1>Listing menus</h1>
+<%= content_for :title, "Menus" %>
+<%= content_for :buttons, (link_to 'New Menu', new_menu_path, class: "button tiny") %>
 
 <table>
   <thead>
@@ -21,5 +22,3 @@
 </table>
 
 <br>
-
-<%= link_to 'New Menu', new_menu_path %>

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -1,9 +1,14 @@
+<%= content_for :title, (@menu.name + " menu") %>
+<% content_for :buttons do %>
+  <%= link_to 'Edit', edit_menu_path(@menu), class: "button tiny" %>
+  <%= link_to 'Back', menus_path, class: "button tiny" %>
+<% end %>
+
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Name:</strong>
-  <%= @menu.name %>
+  <strong>Links:</strong>
+  <% @menu.links.each do |link| %>
+    <%= link_to link.title, link %>
+  <% end %>
 </p>
-
-<%= link_to 'Edit', edit_menu_path(@menu) %> |
-<%= link_to 'Back', menus_path %>


### PR DESCRIPTION
Also expires the cache for the menu in 24 hours, and sorts the menu_links on their preferred order. Does, however, not make it possible to set the links from the menu as this was cumbersome, and does not allow us to change the active menu as I realised we should only have one of these. Maybe we should enforce this?