### PR TITLE
Various UI/UX improvements

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -46,6 +46,9 @@ ul, ol, dl {
 	text-align: center;
 }
 
+.tooltip {
+	margin-top: -10px;
+}
 
 // ELEMENTS
 // Include stuff like headings, links, buttons, forms, element styling ..

--- a/app/assets/stylesheets/_posts.scss
+++ b/app/assets/stylesheets/_posts.scss
@@ -6,9 +6,9 @@
   // font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 
   h1 { font-size: rem-calc(37); }
-  h2 { font-size: rem-calc(27); }
+  h2 { font-size: rem-calc(28); margin-bottom: 5px; font-weight: 400; }
   h3 { font-size: rem-calc(23); }
-  h4 { font-size: rem-calc(18); }
+  h4 { font-size: rem-calc(16); margin-bottom: 0; font-weight: 500; }
   h5 { font-size: 1rem; }
   h6 { font-size: 0.9rem; }
 

--- a/app/assets/stylesheets/_posts.scss
+++ b/app/assets/stylesheets/_posts.scss
@@ -7,8 +7,8 @@
 
   h1 { font-size: rem-calc(37); }
   h2 { font-size: rem-calc(28); margin-bottom: 5px; font-weight: 400; }
-  h3 { font-size: rem-calc(23); }
-  h4 { font-size: rem-calc(16); margin-bottom: 0; font-weight: 500; }
+  h3 { font-size: rem-calc(16); margin-bottom: 0; font-weight: 500; }
+  h4 { font-size: rem-calc(14); margin-bottom: 0; font-weight: 500; }
   h5 { font-size: 1rem; }
   h6 { font-size: 0.9rem; }
 

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -6,7 +6,7 @@ $dark: 					#002224;
 $bg:					#f1f1f1;
 $grey:					#697273;
 $light:					#8b8b8b;
-$teal:					#3c5c5e;
+$teal:					#486163;
 
 $bodycolor:				#323232;
 $btn-color: 			#44AEDB;

--- a/app/assets/stylesheets/common/_buttons.scss
+++ b/app/assets/stylesheets/common/_buttons.scss
@@ -37,6 +37,11 @@
 
 }
 
+.button {
+	border-radius: 2px;
+	font-weight: bold;
+}
+
 .button.smaller {
 	padding: 10px 20px;
 	margin: 0;

--- a/app/assets/stylesheets/common/_buttons.scss
+++ b/app/assets/stylesheets/common/_buttons.scss
@@ -37,9 +37,13 @@
 
 }
 
-.button {
+.button, input[type="submit"] {
 	border-radius: 2px;
 	font-weight: bold;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
 }
 
 .button.smaller {

--- a/app/assets/stylesheets/common/_elements.scss
+++ b/app/assets/stylesheets/common/_elements.scss
@@ -42,7 +42,7 @@ embed,
 iframe {
 	max-width: 100%;
 	height: auto;
-	
+
 	&.noscale {
 		max-width: none;
 	}
@@ -56,8 +56,8 @@ iframe {
 hr {
 	border: 0;
 	height: 1px;
-	background-color: #ccc;
-	margin: $lineheight*2 10%;
+	background-color: #e6e6e6;
+	margin: $lineheight*2 0;
 }
 
 /* User avatars */
@@ -93,4 +93,3 @@ nav ol {
 	margin: 0;
 	padding: 0;
 }
-

--- a/app/assets/stylesheets/common/_forms.scss
+++ b/app/assets/stylesheets/common/_forms.scss
@@ -62,6 +62,8 @@ textarea {
 	width: 120px;
 	height: 38px;
 	margin: 0;
+    border: none;
+    border-radius: 2px;
 
 	&:focus {
 		width: 200px;

--- a/app/assets/stylesheets/common/_forms.scss
+++ b/app/assets/stylesheets/common/_forms.scss
@@ -12,7 +12,9 @@ textarea {
 	-webkit-appearance: none;
 	font: normal 90%/1 $sans;
 	color: $bodycolor;
-	border: 1px solid #bebebe;
+	border: 1px solid #ccc;
+    box-shadow: none;
+    border-radius: 2px;
 	padding: 5px;
 
 	&.large {

--- a/app/assets/stylesheets/common/_headings.scss
+++ b/app/assets/stylesheets/common/_headings.scss
@@ -3,7 +3,7 @@
 
 .huge {
 	font-size: 3em;
-	font-weight: 500;
+	font-weight: 200;
 	letter-spacing: -1px;
 }
 

--- a/app/assets/stylesheets/common/_pages.scss
+++ b/app/assets/stylesheets/common/_pages.scss
@@ -35,7 +35,7 @@
 	}
 }
 
-.sidebar .left{
+.sidebar-list {
 	a:hover {
 		text-decoration: none;
 		color: $primary-color;

--- a/app/assets/stylesheets/common/_pages.scss
+++ b/app/assets/stylesheets/common/_pages.scss
@@ -10,6 +10,12 @@
 	}
 }
 
+@media screen and (min-width: 1025px) {
+    .box-overlap-header {
+        padding: 1.5em;
+        margin-top: -40px;
+    }
+}
 
 .main-col {
 	margin-top: -$lineheight*3;
@@ -31,22 +37,29 @@
 
 .sidebar .left{
 	a:hover {
-		background-color: #eff6f7;
 		text-decoration: none;
-		color: #000;
-    font-weight: 500;
+		color: $primary-color;
+        font-weight: 500;
+        padding-left: 5px;
 	}
 	a {
 		color: #000;
-    font-weight: 500;
+		font-weight: 400;
+		padding: 5px 0;
 		display: block;
 	}
 	hr {
-		margin: 2px;
+		margin: 0;
 	}
 	p {
-		font-weight: 500;
-		color: #999;
+        font-weight: 500;
+        padding: 0px 0;
+        display: block;
+        color: $primary-color;
+        border-left: 3px solid $primary-color;
+        padding-left: 5px;
+        margin-top: 5px;
+        margin-bottom: 5px;
 	}
 	.child {
 		margin-left: 15px;

--- a/app/assets/stylesheets/lib/_helpers.scss
+++ b/app/assets/stylesheets/lib/_helpers.scss
@@ -23,6 +23,8 @@ a.block:hover {
 
 .box {
 	@include box;
+	box-shadow: 0 5px 15px rgba(0,0,0,.1);
+	border-radius: 2px;
 }
 
 .sep {

--- a/app/assets/stylesheets/partials/_calendar.scss
+++ b/app/assets/stylesheets/partials/_calendar.scss
@@ -69,10 +69,10 @@
 	}
 
 	td {
-		border: 1px solid #ccc;
 		text-align: center;
 		color: #ccc;
 		padding: 0;
+		border-radius: 2px;
 	}
 
 	th {
@@ -115,7 +115,7 @@
 	 .gce-has-events,
 	 .it-has-events {
 	 	color: #fff;
-	 	background-color: $btn-color;
+	 	background-color: $primary-color;
 	 	font-weight: bold;
 	 	cursor: default;
 	 }

--- a/app/assets/stylesheets/partials/_footer.scss
+++ b/app/assets/stylesheets/partials/_footer.scss
@@ -29,15 +29,8 @@
 	}
 
 	hgroup {
-		color: $teal;
+		color: #fff;
 		text-align: center;
-		text-shadow: rgba(#000, .8) 0 2px 0;
-		@include transition(color .15s ease-out);
-
-		&:hover {
-			color: lighten($teal, 10%);
-			text-shadow: rgba(#000, .8) 0 2px 0, rgba($teal, .5) 0 0 20px;
-		}
 	}
 
 	dl {
@@ -70,16 +63,22 @@
 }
 
 .footer-foot {
+    background: #0f1617;
+    padding: 20px;
+    color: #fff;
+    text-align: center;
+
 	& > p,
 	& > div {
 		display: inline-block;
 		margin-right: 10px;
 	}
+}
 
-	@media screen and (max-width: 1024px) {
-		text-align: center;
-		margin-top: 24px;
-	}
+.footer-foot-divider {
+    opacity: 0.2;
+    margin-left: 5px;
+    margin-right: 5px;
 }
 
 .footer-nav {

--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -4,9 +4,8 @@
 @import "navigation";
 
 [role="banner"] {
-	@include box-shadow(rgba(#000, .3) 0 1px 10px);
-	border-bottom: 1px solid rgba(#000, .4);
 	margin-bottom: $lineheight / 2;
+	background-color: #212121; // Default bg color, visible while loading
 	background-image: asset-url("header.jpg");
 	background-repeat: no-repeat;
 	background-position: center center;

--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -53,9 +53,19 @@
 	}
 
 	&.horizontal-list .flags img {
-		height: 38px;
+		height: 24px;
 		// vertical-align: top;
 	}
+}
+
+.flags {
+	margin-left: 2em;
+}
+
+.dropdown-trigger {
+    i {
+        margin-left: 5px;
+    }
 }
 
 .header-toolbar {

--- a/app/assets/stylesheets/partials/_navigation.scss
+++ b/app/assets/stylesheets/partials/_navigation.scss
@@ -20,7 +20,7 @@
 	ul {
 		margin: 0;
 	}
-	
+
 	li {
 		&.current_page_item a,
 		&.current-page-ancestor a {
@@ -31,23 +31,10 @@
 
 			position: relative;
 			color: #fff;
-			text-shadow: rgba(#fff, .4) 0 0 3px;
 			cursor: default;
-			@include box-shadow(rgba(#000, .5) 0 2px 5px, inset rgba(#fff, .4) 0 1px 0);
-			@include border-radius(3px);
-
-			&::after {
-				display: block;
-				position: absolute;
-				content: "";
-				@include arrow-down($size: 10px, $color: darken($bg, 10%));
-				bottom: -10px;
-				left: 50%;
-				margin-left: -10px;
-			}
 		}
 	}
-	
+
 	a {
 		color: #ddd;
 		text-transform: uppercase;
@@ -56,10 +43,9 @@
 		white-space: nowrap;
 		letter-spacing: 1px;
 		font-weight: bold;
-		
+
 		&:hover {
 			text-decoration: none;
-			text-shadow: rgba(#fff, .5) 0 0 3px;
 			color: #fff;
 		}
 	}
@@ -130,7 +116,7 @@
 		&:last-child span,
 		&:last-child a {
 			@include border-top-right-radius(3px);
-			@include border-bottom-right-radius(3px);	
+			@include border-bottom-right-radius(3px);
 		}
 	}
 

--- a/app/assets/stylesheets/partials/_sidebar.scss
+++ b/app/assets/stylesheets/partials/_sidebar.scss
@@ -3,7 +3,7 @@
 --------------------------------------- */
 
 .sidebar {
-	
+
 	section {
 
 		& > footer {
@@ -19,7 +19,7 @@
 				color: #333;
 			}
 		}
-	}	
+	}
 }
 
 .side-nav, .sidebar {
@@ -69,7 +69,7 @@
 			display: block;
 			font-size: 1.1em;
 		}
-		
+
 		.date {
 			display: inline-block;
 			width: 56px;

--- a/app/assets/stylesheets/views/_home.scss
+++ b/app/assets/stylesheets/views/_home.scss
@@ -128,7 +128,7 @@
 				color: #000;
 				font-size: 2.5em;
 			}
-			display: block;
+			display: inline-block;
 			position: relative;
 			text-align: center;
 			color: $teal;
@@ -136,7 +136,6 @@
 			text-decoration: none;
 			// padding-top: $lineheight*2;
 			opacity: .8;
-			width: 100%;
 			height: auto;
 			@include transition(all .2s ease-out);
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,10 +14,15 @@ module ApplicationHelper
     entity.translations.any? { |e| e.locale == locale}
   end
 
-  def header_link_to_current(title, path)
+  def header_link_to_current(title, path, controller)
     classes = 'menu-item'
     classes += ' current_page_item' if current_page?(path) || request.fullpath.include?(path)
-    content_tag :li, (link_to title, path), class: classes
+
+    if controller == 'redirect'
+      title += ' <i class="fa fa-external-link"></i>'
+    end
+
+    content_tag :li, (link_to title.html_safe, path), class: classes
   end
 
   def locale_or_nil(locale = I18n.default_locale)

--- a/app/views/calendar/fetch.html.erb
+++ b/app/views/calendar/fetch.html.erb
@@ -1,5 +1,5 @@
     <header>
-        <h3><%= t '.events' %></h3>
+        <h2><%= t '.events' %></h2>
     </header>
     <% cache ['home_calendar', I18n.locale], expires_in: 1.hour do  %>
         <div class="gce-widget-grid">

--- a/app/views/contact/_form.html.erb
+++ b/app/views/contact/_form.html.erb
@@ -2,7 +2,7 @@
   <%= simple_form_for @contact, url: contact_index_path, method: :post do |f| %>
     <%= f.error_notification %>
     <h1><%= Contact.model_name.human(count:1) %></h1>
-    <%= f.input :title %>
+    <%= f.input :title  %>
     <%= f.input :body, input_html: { rows: 10 } %>
     <%= f.input :email, as: :email %>
     <%= f.input :value, label: 'Text', as: :hidden %>

--- a/app/views/contact/_form.html.erb
+++ b/app/views/contact/_form.html.erb
@@ -1,4 +1,4 @@
-<article class="box">
+<article class="box box-overlap-header">
   <%= simple_form_for @contact, url: contact_index_path, method: :post do |f| %>
     <%= f.error_notification %>
     <h1><%= Contact.model_name.human(count:1) %></h1>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -67,25 +67,14 @@
         </section>
       <% end %>
       </div>
-
-      <div class="footer-foot wrapper">
-          <p><small><%= t 'developed_by' %> <a href="https://digit.chalmers.it" title="digIT"> digIT</a>  |  <a href="/humans.txt"><%= t 'more_info' %></a></small>
-        </p>
-
-        <div class="social-sharing">
-        <div class="fb-like"
-          data-href="https://www.facebook.com/chalmers.it"
-          data-send="false"
-          data-layout="button_count"
-          data-width="200"
-          data-colorscheme="dark"
-          data-show-faces="true"></div>
-
-
-        <a href="https://twitter.com/chalmersit" class="twitter-follow-button" data-show-count="false" data-lang="sv" data-size="small" data-dnt="true"><%= t 'follow' %> @chalmersit</a>
-        </div>
       </div>
     </footer>
+    <div class="footer-foot">
+        <div class="wrapper">
+        <p><small><%= t 'developed_by' %> <a href="https://digit.chalmers.it" title="digIT"> digIT</a>  <span class="footer-foot-divider">|</span>  <a href="/humans.txt"><%= t 'more_info' %></a></small></p>
+          </div>
+      </div>
+    </div>
     <%= javascript_include_tag "application" %>
   </body>
 </html>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -98,7 +98,7 @@
               <% end %>
             </li>
             <li class="flags dropdown">
-              <span class="dropdown-trigger"><%= image_tag("flags/#{I18n.locale}.svg") %></span>
+              <span class="dropdown-trigger"><%= image_tag("flags/#{I18n.locale}.svg") %> <i class="fa fa-caret-down"></i></span>
               <ul class="dropdown-sub">
                 <% I18n.available_locales.each do |item| %>
                   <% unless I18n.locale == item %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -49,7 +49,7 @@
             <nav role="navigation" class="main-nav">
               <ul id="menu-huvudnavigation">
                 <% Menu.links_for_menu_cached('main').each do |link| %>
-                  <%= header_link_to_current t(link.title), link.path %>
+                  <%= header_link_to_current t(link.title), link.path, link.controller %>
                 <% end %>
               </ul>
             </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
 <%= yield(:sidebar_left) %>
 </aside>
 <section class="large-6 columns <%= 'large-offset-3' if !content_for?(:sidebar_left) && !content_for?(:sidebar_right) %>">
-  <article class="box" role="article">
+  <article class="box box-overlap-header" role="article">
     <% if content_for? :subtitle %>
       <hgroup class="page-title">
         <h1><%= yield(:title) %></h1>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -64,7 +64,7 @@
   <div class="large-3 medium-6 columns">
     <section class="box widget it-calendar" data-url="<%= url_for controller: 'calendar', action: 'fetch' %>">
       <header>
-          <h3><%= t '.events' %></h3>
+          <h2><%= t '.events' %></h2>
       </header>
 
       <div class="loading-indicator">
@@ -74,7 +74,9 @@
     </section>
 
     <section class="box widget card-balance">
-      <h3><%= t '.student_union_card' %></h3>
+       <header>
+        <h2><%= t '.student_union_card' %></h2>
+      </header>
       <div id="student-union-card">
         <%= render partial: 'card_balance_form' %>
       </div>

--- a/app/views/pages/_sidebar.html.erb
+++ b/app/views/pages/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <% current_committee = nil if local_assigns[:current_committee].nil? %>
 <% current_page = nil if local_assigns[:current_page].nil? %>
 
-<div class="sidebar box left">
+<div class="sidebar sidebar-list box">
   <section>
     <h2><%= t("about_section") %></h2>
     <% @pages.where(parent_id: nil).each do |parent_page| %>


### PR DESCRIPTION
More clean and modern look:
* Softer box shadow and slightly rounded corners
* Slightly rounded corners on buttons
* Content box now overlaps header on non-home: fixes #215 
* Minor changes to footer: separate background color on the credits bar below the footer. white text on Information technology text, to make it more readable.
* Typography styling improvements on pages (headlines are now more grouped with their content and more differentiated from each other).
* Cleaner looking form fields

UX improvements
* Added "external link" icon to all "Redirect" controller menu links. Should clarify that if you click these, you leave chalmers.it. I clicked Courses and Services more than once, expecting to stay on Chalmers.it since they're in the main menu – this is problematic since there is no easy way back on those sites.
* Added dropdown icon beside of the flag. Also made flags smaller since they looked a bit bulky.

Bug fixes
* Consistent padding on content box
* Tooltip position is now better aligned for shortcut links on home. Partly fixes #167. The "arrow" is still slightly off, but the tooltip itself is positioned from the icon/link width now, instead of the whole column.

Before:
<img width="1324" alt="skarmavbild 2016-12-14 kl 14 05 52" src="https://cloud.githubusercontent.com/assets/1730738/21183069/77f3a0ca-c206-11e6-97d2-55e730dcfe4b.png">


After:
<img width="1342" alt="skarmavbild 2016-12-14 kl 14 05 39" src="https://cloud.githubusercontent.com/assets/1730738/21183074/7b44a832-c206-11e6-85dd-261eb199d419.png">