### PR TITLE
Feature/file upload list

### DIFF
--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -5,6 +5,7 @@ en_post_body = '.posts #post_body_en, #page_body_en'
 sv_post_body = '.posts #post_body_sv, #page_body_sv'
 
 $ ->
+  new Clipboard('.copy-file');
 
   $(en_post_body + sv_post_body).fileupload
     url: '/uploads.json',
@@ -63,7 +64,7 @@ insertTextAtCaret = (elem, text) ->
 
 addToFileList = (fileName, url) ->
   content = "<div class='file-entry'><a target='_blank' title='" + fileName + "' href='" + url + "'>" + fileName + "</a>"
-  content += "<button class='button tiny copy-file-link' data-markdown='" + link_markdown(fileName, url) + "'>Copy link</div>"
+  content += "<button class='button tiny copy-file' data-clipboard-text='" + link_markdown(fileName, url) + "'>Copy link</div>"
   #content = fileName + "<i class='fa fa-icon-copy'></i><br>"
   $("#file-list").html(content)
 

--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -36,20 +36,20 @@ $ ->
       src = data.result.source
       extension = src.url.substr(src.url.lastIndexOf('.'), src.url.length)
       if $.inArray(extension, image_exts) > -1
-        addToFileList(data.orig_name, src.url, image_thumbnail_markdown(remove_ext(data.orig_name), src.url, src.thumb.url))
+        add_to_file_list(data.orig_name, src.url, image_thumbnail_markdown(remove_ext(data.orig_name), src.url, src.thumb.url))
       else
-        addToFileList(data.orig_name, src.url, link_markdown(remove_ext(data.orig_name), src.url))
+        add_to_file_list(data.orig_name, src.url, link_markdown(remove_ext(data.orig_name), src.url))
 
   $(post_body).on 'paste', (event) ->
-    postBody = event.currentTarget
-    pastedText = event.originalEvent.clipboardData.getData('text')
-    caretPosition = postBody.selectionStart
-    if pastedText.indexOf("![") == -1 #Ignore images with thumbnails
+    post_body = event.currentTarget
+    pasted_text = event.originalEvent.clipboardData.getData('text')
+    caret_position = post_body.selectionStart
+    if pasted_text.indexOf("![") == -1 #Ignore images with thumbnails
       #Paste event is fired before data is pasted, wait 100ms to make sure that the text is there.
       setTimeout ( ->
-          firstPos = postBody.value.indexOf(pastedText, caretPosition)
-          lastPos = firstPos + pastedText.indexOf("]")
-          postBody.setSelectionRange(firstPos + 1, lastPos - 1)
+          first_pos = post_body.value.indexOf(pasted_text, caret_position)
+          last_pos = first_pos + pasted_text.indexOf("]")
+          post_body.setSelectionRange(first_pos + 1, last_pos)
 
       ), 100
 
@@ -64,9 +64,11 @@ valid_file = (filename) ->
   extension = filename.substr(filename.lastIndexOf('.'), filename.length)
   $.inArray(extension, image_exts) || $.inArray(extension, doc_exts)
 
-addToFileList = (fileName, url, markdown_url) ->
-  content = "<div class='file-entry'><a target='_blank' title='" + fileName + "' href='" + url + "'>" + fileName + "</a>"
-  content += "<button class='button tiny copy-file' data-clipboard-text='" + markdown_url + "'>" + I18n.t('copy_link') + "</div>"
+add_to_file_list = (filename, url, markdown_url) ->
+  content = "<div class='file-entry'>
+              <a target='_blank' title='#{filename}' href='#{url}'> #{filename} </a>
+              <button class='button tiny copy-file' data-clipboard-text='#{markdown_url}'> #{I18n.t('copy_link')} </button>
+            </div>"
   $("#file-list").append(content)
 
 image_markdown = (title, url) ->

--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -66,7 +66,7 @@ addToFileList = (fileName, url) ->
   content = "<div class='file-entry'><a target='_blank' title='" + fileName + "' href='" + url + "'>" + fileName + "</a>"
   content += "<button class='button tiny copy-file' data-clipboard-text='" + link_markdown(fileName, url) + "'>Copy link</div>"
   #content = fileName + "<i class='fa fa-icon-copy'></i><br>"
-  $("#file-list").html(content)
+  $("#file-list").append(content)
 
 image_markdown = (title, url) ->
   "![#{title}](#{url})"

--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -17,7 +17,7 @@ $ ->
         unless valid_file(data.files[0].name)
           handle_file_error(data)
         if data.files[0].name
-          data.orig_name = remove_ext data.files[0].name
+          data.orig_name = data.files[0].name
         else
           data.orig_name = 'image'
         data.submit().error (e) ->
@@ -35,14 +35,11 @@ $ ->
       data.label.remove()
       src = data.result.source
       extension = src.url.substr(src.url.lastIndexOf('.'), src.url.length)
+      console.log(data)
       if $.inArray(extension, image_exts) > -1
-        insertTextAtCaret($(sv_post_body), image_thumbnail_markdown(data.orig_name, src.url, src.thumb.url) + "\n")
-        insertTextAtCaret($(en_post_body), image_thumbnail_markdown(data.orig_name, src.url, src.thumb.url) + "\n")
-        addToFileList(data.orig_name, src.url)
+        addToFileList(data.orig_name, src.url, image_thumbnail_markdown(remove_ext(data.orig_name), src.url, src.thumb.url))
       else
-        insertTextAtCaret($(sv_post_body), link_markdown(data.orig_name, src.url) + "\n")
-        insertTextAtCaret($(en_post_body), link_markdown(data.orig_name, src.url) + "\n")
-        addToFileList(data.orig_name, src.url)
+        addToFileList(data.orig_name, src.url, link_markdown(remove_ext(data.orig_name), src.url))
 
 handle_file_error = (data) ->
   data.label.text I18n.t('unsupported_file_format')
@@ -56,16 +53,9 @@ valid_file = (filename) ->
   console.log extension
   $.inArray(extension, image_exts) || $.inArray(extension, doc_exts)
 
-insertTextAtCaret = (elem, text) ->
-  $elem = $(elem)
-  caretPos = elem[0].selectionStart
-  oldText = $elem.val()
-  $elem.val(oldText.substring(0, caretPos) + text + oldText.substring(caretPos))
-
-addToFileList = (fileName, url) ->
+addToFileList = (fileName, url, markdown_url) ->
   content = "<div class='file-entry'><a target='_blank' title='" + fileName + "' href='" + url + "'>" + fileName + "</a>"
-  content += "<button class='button tiny copy-file' data-clipboard-text='" + link_markdown(fileName, url) + "'>Copy link</div>"
-  #content = fileName + "<i class='fa fa-icon-copy'></i><br>"
+  content += "<button class='button tiny copy-file' data-clipboard-text='" + markdown_url + "'>Copy link</div>"
   $("#file-list").append(content)
 
 image_markdown = (title, url) ->

--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -35,7 +35,6 @@ $ ->
       data.label.remove()
       src = data.result.source
       extension = src.url.substr(src.url.lastIndexOf('.'), src.url.length)
-      console.log(data)
       if $.inArray(extension, image_exts) > -1
         addToFileList(data.orig_name, src.url, image_thumbnail_markdown(remove_ext(data.orig_name), src.url, src.thumb.url))
       else
@@ -50,12 +49,11 @@ handle_file_error = (data) ->
 
 valid_file = (filename) ->
   extension = filename.substr(filename.lastIndexOf('.'), filename.length)
-  console.log extension
   $.inArray(extension, image_exts) || $.inArray(extension, doc_exts)
 
 addToFileList = (fileName, url, markdown_url) ->
   content = "<div class='file-entry'><a target='_blank' title='" + fileName + "' href='" + url + "'>" + fileName + "</a>"
-  content += "<button class='button tiny copy-file' data-clipboard-text='" + markdown_url + "'>Copy link</div>"
+  content += "<button class='button tiny copy-file' data-clipboard-text='" + markdown_url + "'>" + I18n.t('copy_link') + "</div>"
   $("#file-list").append(content)
 
 image_markdown = (title, url) ->

--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -62,7 +62,7 @@ insertTextAtCaret = (elem, text) ->
   $elem.val(oldText.substring(0, caretPos) + text + oldText.substring(caretPos))
 
 addToFileList = (fileName, url) ->
-  content = "<div class='file-entry'><a target='_blank' title='Open file in new tab' href='" + url + "'>" + fileName + "</a>"
+  content = "<div class='file-entry'><a target='_blank' title='" + fileName + "' href='" + url + "'>" + fileName + "</a>"
   content += "<button class='button tiny copy-file-link' data-markdown='" + link_markdown(fileName, url) + "'>Copy link</div>"
   #content = fileName + "<i class='fa fa-icon-copy'></i><br>"
   $("#file-list").html(content)

--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -5,7 +5,7 @@ en_post_body = '.posts #post_body_en, #page_body_en'
 sv_post_body = '.posts #post_body_sv, #page_body_sv'
 
 $ ->
-  new Clipboard('.copy-file');
+  new Clipboard('.copy-file')
 
   $(en_post_body + sv_post_body).fileupload
     url: '/uploads.json',
@@ -40,6 +40,19 @@ $ ->
       else
         addToFileList(data.orig_name, src.url, link_markdown(remove_ext(data.orig_name), src.url))
 
+  $(post_body).on 'paste', (event) ->
+    postBody = event.currentTarget
+    pastedText = event.originalEvent.clipboardData.getData('text')
+    caretPosition = postBody.selectionStart
+    if pastedText.indexOf("![") == -1 #Ignore images with thumbnails
+      #Paste event is fired before data is pasted, wait 100ms to make sure that the text is there.
+      setTimeout ( ->
+          firstPos = postBody.value.indexOf(pastedText, caretPosition)
+          lastPos = firstPos + pastedText.indexOf("]")
+          postBody.setSelectionRange(firstPos + 1, lastPos - 1)
+
+      ), 100
+
 handle_file_error = (data) ->
   data.label.text I18n.t('unsupported_file_format')
   data.progress_bar.remove()
@@ -60,7 +73,7 @@ image_markdown = (title, url) ->
   "![#{title}](#{url})"
 
 link_markdown = (text, url) ->
-    "[#{text}](#{url})"
+  "[#{text}](#{url})"
 
 image_thumbnail_markdown = (title, url, url_thumb) ->
   if url_thumb

--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -37,9 +37,11 @@ $ ->
       if $.inArray(extension, image_exts) > -1
         insertTextAtCaret($(sv_post_body), image_thumbnail_markdown(data.orig_name, src.url, src.thumb.url) + "\n")
         insertTextAtCaret($(en_post_body), image_thumbnail_markdown(data.orig_name, src.url, src.thumb.url) + "\n")
+        addToFileList(data.orig_name, src.url)
       else
         insertTextAtCaret($(sv_post_body), link_markdown(data.orig_name, src.url) + "\n")
         insertTextAtCaret($(en_post_body), link_markdown(data.orig_name, src.url) + "\n")
+        addToFileList(data.orig_name, src.url)
 
 handle_file_error = (data) ->
   data.label.text I18n.t('unsupported_file_format')
@@ -58,6 +60,12 @@ insertTextAtCaret = (elem, text) ->
   caretPos = elem[0].selectionStart
   oldText = $elem.val()
   $elem.val(oldText.substring(0, caretPos) + text + oldText.substring(caretPos))
+
+addToFileList = (fileName, url) ->
+  content = "<div class='file-entry'><a target='_blank' title='Open file in new tab' href='" + url + "'>" + fileName + "</a>"
+  content += "<button class='button tiny copy-file-link' data-markdown='" + link_markdown(fileName, url) + "'>Copy link</div>"
+  #content = fileName + "<i class='fa fa-icon-copy'></i><br>"
+  $("#file-list").html(content)
 
 image_markdown = (title, url) ->
   "![#{title}](#{url})"

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -79,6 +79,7 @@ ul, ol, dl {
 @import "partials/loading-indicator";
 @import "partials/modal";
 @import "partials/documents";
+@import "partials/uploadedfiles";
 // VIEWS
 // Different views, ex. home, profile page, etc.
 

--- a/app/assets/stylesheets/partials/_uploadedfiles.scss
+++ b/app/assets/stylesheets/partials/_uploadedfiles.scss
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   margin-bottom: 7px;
+  justify-content: space-between;
 
   .button {
     margin: 0;

--- a/app/assets/stylesheets/partials/_uploadedfiles.scss
+++ b/app/assets/stylesheets/partials/_uploadedfiles.scss
@@ -1,0 +1,16 @@
+.file-entry {
+  display: flex;
+  align-items: center;
+  margin-bottom: 7px;
+
+  .button {
+    margin: 0;
+    max-height: 1em;
+    display: flex;
+    align-items: center;
+    line-height: 0;
+    padding-left: 1em;
+    padding-right: 1em;
+    margin-left: 10px;
+  }
+}

--- a/app/assets/stylesheets/partials/_uploadedfiles.scss
+++ b/app/assets/stylesheets/partials/_uploadedfiles.scss
@@ -6,11 +6,17 @@
   .button {
     margin: 0;
     max-height: 1em;
+    min-width: 95px;
     display: flex;
     align-items: center;
     line-height: 0;
     padding-left: 1em;
     padding-right: 1em;
     margin-left: 10px;
+  }
+
+  a {
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -34,7 +34,7 @@
     </style>
     
     <!-- Cut/Copy with Javascript -->
-    <script src="https://cdn.rawgit.com/zenorocha/clipboard.js/v1.5.16/dist/clipboard.min.js"></script>
+    <%= javascript_include_tag "https://cdn.rawgit.com/zenorocha/clipboard.js/v1.5.16/dist/clipboard.min.js", async: true %>
 
   </head>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -32,6 +32,9 @@
         background-image: url( <%= randomized_background_image %> );
       }
     </style>
+    
+    <!-- Cut/Copy with Javascript -->
+    <script src="https://cdn.rawgit.com/zenorocha/clipboard.js/v1.5.16/dist/clipboard.min.js"></script>
 
   </head>
 

--- a/app/views/posts/_file_list.html.erb
+++ b/app/views/posts/_file_list.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
     <div class="columns large-12 box">
-      <h2>Uploaded files</h2>
+      <h2><%= t('uploaded_files') %></h2>
       <div id="file-list">
         
       </div>

--- a/app/views/posts/_file_list.html.erb
+++ b/app/views/posts/_file_list.html.erb
@@ -1,0 +1,8 @@
+<div class="row">
+    <div class="columns large-12 box">
+      <h2>Uploaded files</h2>
+      <div id="file-list">
+        
+      </div>
+    </div>
+  </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,6 +2,10 @@
   <%= render 'shared/markdown_help' %>
 <% end %>
 
+<% content_for :sidebar_right do %>
+  <%= render 'file_list' %>
+<% end %>
+
 
 <%= simple_form_for(@post, html: { novalidate: true }) do |f| %>
   <%= render 'shared/error_messages', object: f.object %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,8 @@ en:
   no: No
   partner: Partner
   unsupported_file_format: Unsupported file format (only pdf/md/txt/jpg/jpeg/gif/png/webp)
+  copy_link: Copy link
+  uploaded_files: Uploaded files
   about_section: About our division
   committees_assoiciations: Committees, associations and other instances
   activerecord:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -77,6 +77,8 @@ sv:
   no: Nej
   partner: Samarbetspartner
   unsupported_file_format: Ogiltigt filformat (endast pdf/md/txt/jpg/jpeg/gif/png/webp)
+  copy_link: Kopiera länk
+  uploaded_files: Uppladdade filer
   about_section: Om Sektionen
   committees_assoiciations: Kommittéer, föreningar och andra instanser
 


### PR DESCRIPTION
First step to making it easier to manage the files you upload when creating a post.
It currently looks like this.
![image](https://cloud.githubusercontent.com/assets/4082428/21279439/8ab84ea0-c3e0-11e6-94d6-d36bd6802451.png)

The file link is no longer inserted automatically at caret position.
A problem with this implementation is that if the user leaves the page and goes back the files disappear.

Fixes #162 