### PR TITLE
Make the transition smooth

### DIFF
--- a/app/assets/stylesheets/views/_home.scss
+++ b/app/assets/stylesheets/views/_home.scss
@@ -173,6 +173,7 @@
 			text-decoration: none;
 			// padding-top: $lineheight*2;
 			opacity: .8;
+			top: 0;
 			height: auto;
 			@include transition(all .2s ease-out);
 


### PR DESCRIPTION
Currently, when you hover over any of the "quick buttons" it results in being quite jumpy. With this change you will make sure that the "transition all" also makes sure to move the button smoothly between 0px -> -5px.