### PR TITLE
Correct comment count for posts, fixes #242

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,7 +14,6 @@ class PostsController < ApplicationController
   # GET /posts/1.json
   def show
     @comments = @post.comments.latest_last
-    @comment = @post.comments.build
     if request.path != post_path(@post)
       redirect_to @post, status: :moved_permanently
     end

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [@post, @comment] do |f| %>
+<%= simple_form_for [@post, comment] do |f| %>
   <%= f.error_notification %>
   <div class="row comment-area">
     <div class="large-12 columns">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -16,7 +16,7 @@
     <% end %>
   <% if policy(Comment).create? %>
     <section id="respond">
-      <%= render 'comments/form' %>
+      <%= render 'comments/form', comment: @post.comments.build %>
     </section>
   <% else %>
     <section id="respond" class="message">


### PR DESCRIPTION
The empty comment @post.comments.build in the post controller messed up the comment count for the post.