### PR TITLE
Remove max-height on title-with-buttons

### DIFF
--- a/app/assets/stylesheets/common/_headings.scss
+++ b/app/assets/stylesheets/common/_headings.scss
@@ -106,5 +106,4 @@ h5 {
 .title-with-buttons {
 	display: flex;
 	justify-content: space-between;
-	max-height: 5em;
 }


### PR DESCRIPTION
fixes #231 

Not super pleased with the solution, as it makes for large margins on some pages. But works fine on most pages:

![2017-02-21-212023_745x592_scrot](https://cloud.githubusercontent.com/assets/2412457/23183223/9b6bd850-f87b-11e6-829f-b6d813cbbabc.png)
