### PR TITLE
Add master reception committee to seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,6 +22,7 @@
   {title_en: 'Chugging Committee', title_sv: 'Häfv och odygd', name: 'HookIT', url: 'http://hookit.chalmers.it', email: 'hookit@chalmers.it' },
   {title_en: 'Auditors', title_sv: 'Sektionens revisorer', name: 'Revisorer', url: 'http://revisorer.chalmers.it', email: 'revisorer@chalmers.it' },
   {title_en: 'Nomination Committee', title_sv: 'Valberedning', name: 'Valberedningen', url: 'http://valberedningen.chalmers.it', email: 'valberedningen@chalmers.it'  },
+  {title_en: 'Master Reception Committee', title_sv: 'Mastermottagningskommitté', name: 'MRCIT', url: 'http://mrcit.chalmers.it', email: 'mrcit@chalmers.it'  },
   {title_en: 'Legacy', title_sv: 'Legacy', name: 'Legacy', url: 'http://chalmers.it', email: 'digit@chalmers.it'  }
 ]
 


### PR DESCRIPTION
Needs manual migration in production.

Also, their subdomain might not be set up?