### PR TITLE
Fix deprication warning for Calendar

### DIFF
--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -25,7 +25,7 @@ class Calendar
   private
     def calendar_data
       cal_data = Net::HTTP.get(URI.parse(self.url))
-      cals = Icalendar.parse cal_data
+      cals = Icalendar::Calendar.parse cal_data
       calendar = cals.first;
       events = calendar.events
 


### PR DESCRIPTION
```
**** DEPRECATION WARNING ****
Icalendar.parse will be removed. Please switch to Icalendar::Calendar.parse.
```