### PR TITLE
Suggested fix for #166

### DIFF
--- a/app/assets/stylesheets/_viewports.scss
+++ b/app/assets/stylesheets/_viewports.scss
@@ -23,4 +23,10 @@
   #site-menu {
     display: block !important;
   }
+  .small-today-events {
+    display: none;
+  }
+  .default-today-events {
+    display: block;
+  }
 }

--- a/app/assets/stylesheets/viewports/_medium.scss
+++ b/app/assets/stylesheets/viewports/_medium.scss
@@ -111,4 +111,11 @@
 			}
 		}
 	}
+
+	.small-today-events {
+		display: block;
+	}
+	.default-today-events {
+		display: none;
+	}
 }

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -9,7 +9,7 @@
       </h1>
     </div>
   </div>
-  <div class="quick-buttons large-5 columns">
+  <div class="quick-buttons large-8 columns">
     <ul class="box list text-center">
         <li><a data-tooltip data-options="disable_for_touch:true" title="TimeEdit" href="https://se.timeedit.net/web/chalmers/db1/public/ri1Q7.html" target="_blank" class="has-tip tip-top"><div class="quick-button-chalmers"><i class="fa fa-graduation-cap"></i></div> <%= fa_icon 'table', text: t('.schema') %></a></li>
         <li><a data-tooltip data-options="disable_for_touch:true" title="<%= t '.book_chalmers_desc' %>" href="https://se.timeedit.net/web/chalmers/db1/b1/" target="_blank" class="has-tip tip-top"><div class="quick-button-chalmers"><i class="fa fa-graduation-cap"></i></div> <%= fa_icon 'users', text: t('.group_room') %></a></li>
@@ -19,7 +19,7 @@
         <li><a data-tooltip data-options="disable_for_touch:true" title="<%= t '.slack_desc' %>" href="https://slack.chalmers.it/signup" target="_blank" class="has-tip tip-top"><%= fa_icon 'slack', text: t('.slack') %></a></li>
     </ul>
   </div>
-  <div class="user-area large-3 columns">
+  <div class="user-area large-3 columns small-today-events">
     <%= render 'home/today', events: @events %>
   </div>
 </header>
@@ -62,6 +62,11 @@
     <% end %>
   </div>
   <div class="large-3 medium-6 columns">
+
+    <div class="widget default-today-events">
+      <%= render 'home/today', events: @events %>
+    </div>
+
     <section class="box widget">
       <header>
         <h2><%= t '.events' %></h2>


### PR DESCRIPTION
Duplicates the upcoming events box and hides either one when appropriate. Feels like a bit of a hack, maybe someone has a better suggestion?

Adds the upcoming events box to the widget row on large screens:
![2017-10-26-163900_2636x373_scrot](https://user-images.githubusercontent.com/2412457/32059414-5ced9d62-ba6c-11e7-8fe9-1a17a442943f.png)

And on medium screens and down, preserves original look:
![2017-10-26-163912_1820x521_scrot](https://user-images.githubusercontent.com/2412457/32059415-5d09a8fe-ba6c-11e7-9ee0-e493d1fd42d8.png)

(Merging to master intentionally)