### PR TITLE
Bugfix the contact form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,8 @@ group :development do
 
   # Measure the request time, for profiling
   gem 'rack-mini-profiler'
+
+  gem 'mailcatcher'
 end
 
 gem 'rspec-rails', group: [:test, :development]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,12 +124,14 @@ GEM
     configurable_engine (0.4.8)
       rails (> 3.1.0)
     crass (1.0.3)
+    daemons (1.2.6)
     diff-lcs (1.3)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
     erubi (1.7.0)
     erubis (2.7.0)
+    eventmachine (1.2.7)
     execjs (2.7.0)
     factory_girl (4.9.0)
       activesupport (>= 3.0.0)
@@ -174,6 +176,9 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    haml (5.0.4)
+      temple (>= 0.8.0)
+      tilt
     hashie (3.5.6)
     html-pipeline (2.7.1)
       activesupport (>= 2)
@@ -218,6 +223,16 @@ GEM
     lumberjack (1.0.12)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
+    mailcatcher (0.2.4)
+      eventmachine
+      haml
+      i18n
+      json
+      mail
+      sinatra
+      skinny (>= 0.1.2)
+      sqlite3-ruby
+      thin
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.9.0)
@@ -234,6 +249,7 @@ GEM
     multi_json (1.12.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mustermann (1.0.2)
     mysql2 (0.4.10)
     naught (1.1.0)
     nenv (0.3.0)
@@ -274,6 +290,8 @@ GEM
     rack (2.0.3)
     rack-mini-profiler (0.10.6)
       rack (>= 1.2.0)
+    rack-protection (2.0.1)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.2)
@@ -370,6 +388,14 @@ GEM
       actionpack (> 4, < 5.2)
       activemodel (> 4, < 5.2)
     simple_oauth (0.3.1)
+    sinatra (2.0.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.1)
+      tilt (~> 2.0)
+    skinny (0.2.2)
+      eventmachine (~> 1.0)
+      thin
     slack-notifier (2.0.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -380,6 +406,14 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
+    sqlite3-ruby (1.3.3)
+      sqlite3 (>= 1.3.3)
+    temple (0.8.0)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -443,6 +477,7 @@ DEPENDENCIES
   jquery-fileupload-rails
   jquery-rails
   json
+  mailcatcher
   mini_magick
   momentjs-rails
   multi_fetch_fragments

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -8,13 +8,13 @@ class ContactController < ApplicationController
 
   def create
       contact_params = params[:contact]
-      if !contact_params[:body].blank? and check_addresses(contact_params[:to_whom])
-        mail_array = contact_params[:to_whom] << contact_params[:email]
+      if !contact_params[:body].blank? and check_addresses?(contact_params[:to_whom])
+          mail_array = contact_params[:to_whom] << contact_params[:email]
 
-        GroupMailer.anonymous_mail(mail_array, contact_params[:body], contact_params[:title]).deliver_now
-        redirect_to :contact_index, flash: {notice: I18n.translate('mail_sent', recipents: build_contacts_string(contact_params[:to_whom]))}
+          GroupMailer.anonymous_mail(mail_array, contact_params[:body], contact_params[:title]).deliver_now
+          redirect_to :contact_index, flash: {notice: I18n.translate('mail_sent', recipents: build_contacts_string(contact_params[:to_whom]))}
       else
-        redirect_to :contact_index, flash: {error: I18n.translate('mail_error')}
+          redirect_to :contact_index, flash: {error: I18n.translate('mail_error')}
       end
   end
 
@@ -35,7 +35,7 @@ class ContactController < ApplicationController
         return_string.gsub("@chalmers.it","")
     end
 
-    def check_addresses(to_whom)
-      !to_whom.blank? and to_whom.all? {|to| Contact.available_mails.include?(to) or to.empty?}
+    def check_addresses?(to_whom)
+        !to_whom.blank? and to_whom.all? {|to| Contact.available_mails.include?(to) or to.empty?}
     end
 end

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -8,13 +8,14 @@ class ContactController < ApplicationController
 
   def create
       contact_params = params[:contact]
-      if params[:value].blank? && !contact_params[:to_whom].blank? && Contact.available_mails.include?(contact_params[:to_whom].first)
+      if !contact_params[:body].blank? and check_addresses(contact_params[:to_whom])
         mail_array = contact_params[:to_whom] << contact_params[:email]
 
         GroupMailer.anonymous_mail(mail_array, contact_params[:body], contact_params[:title]).deliver_now
+        redirect_to :contact_index, flash: {notice: I18n.translate('mail_sent', recipents: build_contacts_string(contact_params[:to_whom]))}
+      else
+        redirect_to :contact_index, flash: {error: I18n.translate('mail_error')}
       end
-
-      redirect_to :contact_index, flash: {notice: I18n.translate('mail_sent', recipents: build_contacts_string(contact_params[:to_whom]))}
   end
 
   def new
@@ -32,5 +33,9 @@ class ContactController < ApplicationController
             return_string = contacts_arr.first(contacts_arr.size - 1).join(', ') + I18n.translate('and') + contacts_arr.last
         end
         return_string.gsub("@chalmers.it","")
+    end
+
+    def check_addresses(to_whom)
+      !to_whom.blank? and to_whom.all? {|to| Contact.available_mails.include?(to) or to.empty?}
     end
 end

--- a/app/views/contact/_form.html.erb
+++ b/app/views/contact/_form.html.erb
@@ -7,10 +7,13 @@
     <%= f.input :email, as: :email %>
     <%= f.input :value, label: 'Text', as: :hidden %>
     <%= f.label t('to_whom') %>
-    <%= f.collection_check_boxes :to_whom, [['styrit@chalmers.it', 'styrIT'],
-    		['samo@chalmers.it', 'SAMO'], ['snit@chalmers.it', 'snIT'],
-    		['valberedningen@chalmers.it', 'Valberedningen'], 
-    		['digit@chalmers.it', 'digIT']], :first, :last %>
+    <%= f.collection_check_boxes :to_whom, [
+            ['styrit@chalmers.it', 'styrIT'],
+            ['samo@chalmers.it', 'SAMO'],
+            ['snit@chalmers.it', 'snIT'],
+            ['valberedningen@chalmers.it', 'Valberedningen'],
+            ['digit@chalmers.it', 'digIT']
+        ], :first, :last %>
     <%= f.button :submit, t('send_contact') %>
 
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@
 en:
   and: " and "
   mail_sent: "Your mail has been sent to %{recipents}"
+  mail_error: "Your mail could not be delivered (empty body or recipients)"
   page_title: Information Technology on Chalmers
   techsec: Student Division
   section: The division

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -482,7 +482,7 @@ en:
       contact:
         body: Body
         title: Title
-        email: Email (Leave empty if you want to be anonymous)
+        email: Your email (Leave empty if you want to be anonymous)
         contact_form: Kontaktformulär
     placeholders:
       print:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -22,6 +22,7 @@
 sv:
   and: " och "
   mail_sent: "Ditt mail har skickats till %{recipents}"
+  mail_error: "Ditt mail kunde inte skickas (tomt meddelande eller mottagare)"
   page_title: Informationsteknik på Chalmers
   techsec: Teknologsektionen
   section: Sektionen

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -482,7 +482,7 @@ sv:
       contact:
         body: Innehåll
         title: Ämne
-        email: Epostadress (Fyll inte i om du vill vara anonym)
+        email: Din e-postadress (Fyll inte i om du vill vara anonym)
     placeholders:
       print:
         username: CID


### PR DESCRIPTION
Fixes #358 

Works in development at least.  Not sure I understood why we only ever checked the first of the emails in the `to_whom` list (which contained `["", "digit@chalmers.it"]`, which is why it didn't work now).