### PR TITLE
Remove thumb version and bump size of images

### DIFF
--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -36,7 +36,7 @@ $ ->
       src = data.result.source
       extension = src.url.substr(src.url.lastIndexOf('.'), src.url.length)
       if $.inArray(extension, image_exts) > -1
-        add_to_file_list(data.orig_name, src.url, image_thumbnail_markdown(remove_ext(data.orig_name), src.url, src.thumb.url))
+        add_to_file_list(data.orig_name, src.url, image_markdown(remove_ext(data.orig_name), src.url))
       else
         add_to_file_list(data.orig_name, src.url, link_markdown(remove_ext(data.orig_name), src.url))
 
@@ -76,12 +76,6 @@ image_markdown = (title, url) ->
 
 link_markdown = (text, url) ->
   "[#{text}](#{url})"
-
-image_thumbnail_markdown = (title, url, url_thumb) ->
-  if url_thumb
-    link_markdown(image_markdown(title, url_thumb), url)
-  else
-    image_markdown(title, url)
 
 remove_ext = (filename) ->
   filename.substr(0, filename.lastIndexOf('.'))

--- a/app/uploaders/article_image_uploader.rb
+++ b/app/uploaders/article_image_uploader.rb
@@ -24,12 +24,7 @@ class ArticleImageUploader < CarrierWave::Uploader::Base
   #
   #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
   # end
-  process resize_to_limit: [1000, 1000], :if => :image?
-
-  # Create different versions of your uploaded files:
-  version :thumb, if: :too_large? do
-    process :resize_to_limit => [500, 500]
-  end
+  process resize_to_limit: [1500, 1500], :if => :image?
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:


### PR DESCRIPTION
Fixes #342  Increased the size of images.  Not sure if anyone has input on how large we should make them.

Before:
![2018-10-13-170630_1636x1134_scrot](https://user-images.githubusercontent.com/2412457/46906931-37a5c200-cf0b-11e8-91a3-6c014c4401dc.png)

Now:
![2018-10-13-170639_1547x1282_scrot](https://user-images.githubusercontent.com/2412457/46906930-370d2b80-cf0b-11e8-8625-fc7f1b98b288.png)