### PR TITLE
Primarily changed some http links to https

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,5 +1,5 @@
 class Contact < ActiveRecord::Base
   def self.available_mails
-    %w(styrit@chalmers.it samo@chalmers.it snit@chalmers.it valberedningen@chalmers.it digit@chalmers.it)
+    %w(styrit@chalmers.it samo@chalmers.it snit@chalmers.it valberedningen@chalmers.it inte@dhack.se)
   end
 end

--- a/app/views/contact/_form.html.erb
+++ b/app/views/contact/_form.html.erb
@@ -12,7 +12,7 @@
             ['samo@chalmers.it', 'SAMO'],
             ['snit@chalmers.it', 'snIT'],
             ['valberedningen@chalmers.it', 'Valberedningen'],
-            ['digit@chalmers.it', 'digIT']
+            ['inte@dhack.se', 'digIT']
         ], :first, :last %>
     <%= f.button :submit, t('send_contact') %>
 

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -71,7 +71,7 @@
     </footer>
     <div class="footer-foot">
         <div class="wrapper">
-        <p><small><%= t 'developed_by' %> <a href="https://digit.chalmers.it" title="digIT"> digIT</a>  <span class="footer-foot-divider">|</span>  <a href="/humans.txt"><%= t 'more_info' %></a></small></p>
+        <p><small><%= t 'developed_by' %> <a href="https://inte.dhack.se" title="digIT"> digIT</a>  <span class="footer-foot-divider">|</span>  <a href="/humans.txt"><%= t 'more_info' %></a></small></p>
           </div>
       </div>
     </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@
   {title_en: 'PR & Rustmästeri', title_sv: 'PR & Rustmästeri', name: 'P.R.I.T.', url: 'http://prit.chalmers.it', email: 'prit@chalmers.it' },
   {title_en: 'Student Reception Committee', title_sv: 'Mottagningskommitté', name: 'NollKIT', url: 'http://nollk.it', email: 'nollkit@chalmers.it' },
   {title_en: 'Business Relations Committee', title_sv: 'Arbetsmarknad', name: 'ArmIT', url: 'http://armit.se', email: 'armit@chalmers.it' },
-  {title_en: 'Digital systems', title_sv: 'Digitala system', name: 'digIT', url: 'http://digit.chalmers.it', email: 'digit@chalmers.it' },
+  {title_en: 'Digital systems', title_sv: 'Digitala system', name: 'digIT', url: 'http://inte.dhack.se', email: 'inte@dhack.se' },
   {title_en: 'Standard Bearers', title_sv: 'Fanbärare', name: 'FanbärerIT', url: 'http://fanbärerit.chalmers.it', email: 'fanbärerit@chalmers.it' },
   {title_en: 'Physical Activities', title_sv: 'Fysiska aktiviteter', name: 'frITid', url: 'http://fritid.chalmers.it', email: 'fritid@chalmers.it' },
   {title_en: 'Digital games', title_sv: 'Digitala spel', name: '8-bIT', url: 'http://8bit.chalmers.it', email: '8bit@chalmers.it' },
@@ -23,7 +23,7 @@
   {title_en: 'Auditors', title_sv: 'Sektionens revisorer', name: 'Revisorer', url: 'http://revisorer.chalmers.it', email: 'revisorer@chalmers.it' },
   {title_en: 'Nomination Committee', title_sv: 'Valberedning', name: 'Valberedningen', url: 'http://valberedningen.chalmers.it', email: 'valberedningen@chalmers.it'  },
   {title_en: 'Master Reception Committee', title_sv: 'Mastermottagningskommitté', name: 'MRCIT', url: 'http://mrcit.chalmers.it', email: 'mrcit@chalmers.it'  },
-  {title_en: 'Legacy', title_sv: 'Legacy', name: 'Legacy', url: 'http://chalmers.it', email: 'digit@chalmers.it'  }
+  {title_en: 'Legacy', title_sv: 'Legacy', name: 'Legacy', url: 'http://chalmers.it', email: 'inte@dhack.se'  }
 ]
 
  Committee.delete_all

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,23 +7,23 @@
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
  coms = [
-  {title_en: 'Student Division Board', title_sv: 'Styrelse', name: 'styrIT', url: 'http://styrit.chalmers.it', email: 'styrit@chalmers.it' },
-  {title_en: 'Student Educational Committee', title_sv: 'Studienämnd', name: 'snIT', url: 'http://snit.chalmers.it', email: 'snit@chalmers.it' },
-  {title_en: 'Sexmästeri', title_sv: 'Sexmästeri', name: 'sexIT', url: 'http://sexit.chalmers.it', email: 'sexit@chalmers.it' },
-  {title_en: 'PR & Rustmästeri', title_sv: 'PR & Rustmästeri', name: 'P.R.I.T.', url: 'http://prit.chalmers.it', email: 'prit@chalmers.it' },
-  {title_en: 'Student Reception Committee', title_sv: 'Mottagningskommitté', name: 'NollKIT', url: 'http://nollk.it', email: 'nollkit@chalmers.it' },
-  {title_en: 'Business Relations Committee', title_sv: 'Arbetsmarknad', name: 'ArmIT', url: 'http://armit.se', email: 'armit@chalmers.it' },
-  {title_en: 'Digital systems', title_sv: 'Digitala system', name: 'digIT', url: 'http://inte.dhack.se', email: 'inte@dhack.se' },
-  {title_en: 'Standard Bearers', title_sv: 'Fanbärare', name: 'FanbärerIT', url: 'http://fanbärerit.chalmers.it', email: 'fanbärerit@chalmers.it' },
-  {title_en: 'Physical Activities', title_sv: 'Fysiska aktiviteter', name: 'frITid', url: 'http://fritid.chalmers.it', email: 'fritid@chalmers.it' },
-  {title_en: 'Digital games', title_sv: 'Digitala spel', name: '8-bIT', url: 'http://8bit.chalmers.it', email: '8bit@chalmers.it' },
-  {title_en: 'Analog games', title_sv: 'Analoga spel', name: 'DrawIT', url: 'http://drawit.chalmers.it', email: 'drawit@chalmers.it' },
-  {title_en: 'Photo Committee', title_sv: 'Foto', name: 'FlashIT', url: 'http://flashit.chalmers.it', email: 'flashit@chalmers.it' },
-  {title_en: 'Chugging Committee', title_sv: 'Häfv och odygd', name: 'HookIT', url: 'http://hookit.chalmers.it', email: 'hookit@chalmers.it' },
-  {title_en: 'Auditors', title_sv: 'Sektionens revisorer', name: 'Revisorer', url: 'http://revisorer.chalmers.it', email: 'revisorer@chalmers.it' },
-  {title_en: 'Nomination Committee', title_sv: 'Valberedning', name: 'Valberedningen', url: 'http://valberedningen.chalmers.it', email: 'valberedningen@chalmers.it'  },
-  {title_en: 'Master Reception Committee', title_sv: 'Mastermottagningskommitté', name: 'MRCIT', url: 'http://mrcit.chalmers.it', email: 'mrcit@chalmers.it'  },
-  {title_en: 'Legacy', title_sv: 'Legacy', name: 'Legacy', url: 'http://chalmers.it', email: 'inte@dhack.se'  }
+  {title_en: 'Student Division Board', title_sv: 'Styrelse', name: 'styrIT', url: 'https://styrit.chalmers.it', email: 'styrit@chalmers.it' },
+  {title_en: 'Student Educational Committee', title_sv: 'Studienämnd', name: 'snIT', url: 'https://snit.chalmers.it', email: 'snit@chalmers.it' },
+  {title_en: 'Sexmästeri', title_sv: 'Sexmästeri', name: 'sexIT', url: 'https://sexit.chalmers.it', email: 'sexit@chalmers.it' },
+  {title_en: 'PR & Rustmästeri', title_sv: 'PR & Rustmästeri', name: 'P.R.I.T.', url: 'https://prit.chalmers.it', email: 'prit@chalmers.it' },
+  {title_en: 'Student Reception Committee', title_sv: 'Mottagningskommitté', name: 'NollKIT', url: 'https://nollk.it', email: 'nollkit@chalmers.it' },
+  {title_en: 'Business Relations Committee', title_sv: 'Arbetsmarknad', name: 'ArmIT', url: 'https://armit.se', email: 'armit@chalmers.it' },
+  {title_en: 'Digital systems', title_sv: 'Digitala system', name: 'digIT', url: 'https://inte.dhack.se', email: 'inte@dhack.se' },
+  {title_en: 'Standard Bearers', title_sv: 'Fanbärare', name: 'FanbärerIT', url: 'https://fanbärerit.chalmers.it', email: 'fanbärerit@chalmers.it' },
+  {title_en: 'Physical Activities', title_sv: 'Fysiska aktiviteter', name: 'frITid', url: 'https://fritid.chalmers.it', email: 'fritid@chalmers.it' },
+  {title_en: 'Digital games', title_sv: 'Digitala spel', name: '8-bIT', url: 'https://8bit.chalmers.it', email: '8bit@chalmers.it' },
+  {title_en: 'Analog games', title_sv: 'Analoga spel', name: 'DrawIT', url: 'https://drawit.chalmers.it', email: 'drawit@chalmers.it' },
+  {title_en: 'Photo Committee', title_sv: 'Foto', name: 'FlashIT', url: 'https://flashit.chalmers.it', email: 'flashit@chalmers.it' },
+  {title_en: 'Chugging Committee', title_sv: 'Häfv och odygd', name: 'HookIT', url: 'https://hookit.chalmers.it', email: 'hookit@chalmers.it' },
+  {title_en: 'Auditors', title_sv: 'Sektionens revisorer', name: 'Revisorer', url: 'https://revisorer.chalmers.it', email: 'revisorer@chalmers.it' },
+  {title_en: 'Nomination Committee', title_sv: 'Valberedning', name: 'Valberedningen', url: 'https://valberedningen.chalmers.it', email: 'valberedningen@chalmers.it'  },
+  {title_en: 'Master Reception Committee', title_sv: 'Mastermottagningskommitté', name: 'MRCIT', url: 'https://mrcit.chalmers.it', email: 'mrcit@chalmers.it'  },
+  {title_en: 'Legacy', title_sv: 'Legacy', name: 'Legacy', url: 'https://chalmers.it', email: 'inte@dhack.se'  }
 ]
 
  Committee.delete_all


### PR DESCRIPTION
---

For improved SEO[⁷³][7] rankings some http links have been changed to https[¹][1]. 

We're certain that this new change will follow the monad laws[⁰¹⁰⁰⁰¹⁰¹][8] because it has been thoroughly tested in order to be sure that they follow the latest rules and regulations regarding ruby/http, or as I've taken to calling it, ruby+http. HTTP is not a webserver unto itself, but rather another free component of a functional programming related protocol made useful by the ruby-on-rails corelibs, shell utilities and vital system components comprising a full stack web solution as defined by Hacke. 

We've accomplished this using rings[⁰][10], commonly also called "semirings" but by analogy with semigroups it would be more appropriate to use "semirings" for a ring having neither negatives nor a zero, so that is what we did here.

We have made the best efforts possible to adhere to your **VERY** thorough contributing guidelines[⁷][3], especially the part about git flow[⁴²][4] was very inspiring and we did as best we could in following those awe-inspiring principles considering the very limited time frame available to accomplish this.

On top of all this all changes adhere to the policies and regulations set forth by ISO/IEC 30170:2012[²][2]

Also note that more information has been sent to digIT[¹⁸][9] through the proper secure channels[¹³³⁷][5] that we recently set up for you. This email contains confidential information referring to this pull request as well as other projects that we for obvious reason can't discuss here. If it seems like the information hasn't reached you, please contact us immediately.

Signed-off-by: IT-smurfen <inte@dhack.se>
Acked-by: dHack <secure.channels@dhack.se>
Signed-off-by: Hacke Hackspett <hacke@dhack.se>

---

![dhacklogo](https://user-images.githubusercontent.com/5941808/51446333-fcd4d680-1d10-11e9-803f-26afe090f773.png)
[³][6]

---

\[0\]: https://wiki.haskell.org/Category_theory
\[1\] : https://www.bluecorona.com/blog/https-and-seo
\[2\] : https://www.iso.org/standard/59579.html
\[3\]: https://demeter.dtek.se/wiki/Main/DHack
\[7\] : https://github.com/cthit/chalmersit-rails/blob/master/CONTRIBUTING.md
\[18\]: https://inte.dhack.se
\[42\] : https://nvie.com/posts/a-successful-git-branching-model/
\[72\]: https://en.wikipedia.org/wiki/Seo
\[1337\] : https://en.wikipedia.org/wiki/Secure_channel
\[01000101\]: https://wiki.haskell.org/Monad_laws

---

[1]: https://www.bluecorona.com/blog/https-and-seo
[2]: https://www.iso.org/standard/59579.html
[3]: https://github.com/cthit/chalmersit-rails/blob/master/CONTRIBUTING.md
[4]: https://nvie.com/posts/a-successful-git-branching-model/
[5]: https://en.wikipedia.org/wiki/Secure_channel
[6]: https://demeter.dtek.se/wiki/Main/DHack
[7]: https://en.wikipedia.org/wiki/Seo
[8]: https://wiki.haskell.org/Monad_laws
[9]: https://inte.dhack.se
[10]: https://wiki.haskell.org/Category_theory