### PR TITLE
Allow uploads from edits

### DIFF
--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -15,20 +15,21 @@ $ ->
     paramName: 'upload[source]',
     add: (e, data) ->
       this_upload_name = data.files[0].name
-      unless last_upload_name == this_upload_name &&
+      unless last_upload_name == this_upload_name
         last_upload_name = this_upload_name
         data.progress_bar = $('<progress max="100" value="0" class="image-upload">').insertAfter($('.attach-files'))
         data.label = $('<label>').insertAfter(data.progress_bar)
         try
           unless valid_file(this_upload_name)
-            handle_file_error(data)
+            handle_file_error(data, 'unsupported_file_format', "")
           else
             if this_upload_name
               data.orig_name = this_upload_name
             else
               data.orig_name = 'image'
             data.submit().error (e) ->
-              handle_file_error(data)
+              console.log(e)
+              handle_file_error(data, 'upload_failed', e.status + " " + e.statusText)
     progress: (e, data) ->
       percent = parseInt(data.loaded / data.total * 100, 10)
       if percent < 99
@@ -60,8 +61,8 @@ $ ->
 
       ), 100
 
-handle_file_error = (data) ->
-  data.label.text I18n.t('unsupported_file_format')
+handle_file_error = (data, error_label, errortext) ->
+  data.label.text I18n.t(error_label, error: errortext)
   data.progress_bar.remove()
   setTimeout ->
     data.label.remove()

--- a/app/assets/javascripts/uploads.js.coffee
+++ b/app/assets/javascripts/uploads.js.coffee
@@ -28,7 +28,6 @@ $ ->
             else
               data.orig_name = 'image'
             data.submit().error (e) ->
-              console.log(e)
               handle_file_error(data, 'upload_failed', e.status + " " + e.statusText)
     progress: (e, data) ->
       percent = parseInt(data.loaded / data.total * 100, 10)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,7 @@ en:
   no: No
   partner: Partner
   unsupported_file_format: Unsupported file format (only pdf/md/txt/jpg/jpeg/gif/png/webp)
+  upload_failed: "The upload failed with %{error}"
   copy_link: Copy link
   uploaded_files: Uploaded files
   about_section: About our division

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -90,6 +90,7 @@ sv:
   no: Nej
   partner: Samarbetspartner
   unsupported_file_format: Ogiltigt filformat (endast pdf/md/txt/jpg/jpeg/gif/png/webp)
+  upload_failed: "Filuppladningen misslyckades med %{error}"
   copy_link: Kopiera länk
   uploaded_files: Uppladdade filer
   about_section: Om Sektionen

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get 'redirect/courses' => 'redirect#courses'
 
   resources :uploads, only: [:create, :destroy]
+  patch '/uploads.json', to: 'uploads#create'
 
   get 'twitter/feed/:twitter_handle' => 'twitter#feed'
 


### PR DESCRIPTION
By allowing `patch` on `/uploads.json`.  I feel like there should be a better way to solve this, but rails overwrites any options on `fileupload` in `uploads.js.coffee`.