### PR TITLE
No more printer name flickering

### DIFF
--- a/app/views/print/new.html.erb
+++ b/app/views/print/new.html.erb
@@ -16,7 +16,7 @@
         <%= fa_icon 'print' %>
       </span>
     </div>
-    <%= f.input :printer, label: false, class: 'small-9 large-11 columns' do %>
+    <%= f.input :printer, label: false, wrapper_html: {class: 'small-9 large-11 columns'} do %>
       <%= f.select :printer, [] %>
     <% end %>
   </div>


### PR DESCRIPTION
Have you noticed how the printer input flickers before the javascript does it's thing?
Add that to the history books after merging this PR.