### PR TITLE
Update Student Division english name

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,10 +23,10 @@ en:
   and: " and "
   mail_sent: "Your mail has been sent to %{recipents}"
   mail_error: "Your mail could not be delivered (empty body or recipients)"
-  page_title: Information Technology on Chalmers
+  page_title: Software Engineering (IT) on Chalmers
   techsec: Student Division
   section: The division
-  it: Information Technology
+  it: Software Engineering (IT)
   chs: Chalmers Student Union
   cth: Chalmers University of Technology
   login: Sign in

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -17,7 +17,7 @@
                                  |___/
 
 
-Information Technology at Chalmers University of Technology
+Software Engineering (IT) at Chalmers University of Technology
 
 # Questions, bug reports or suggestions:
 #


### PR DESCRIPTION
The name of the webpage should match changes from the student division meeting 2020-05-14

"Proposition om Sektionens engelska namn"

Sektionens engelska namn är ”the Software Engineering Student Division”.

Den svenska akronymen ”IT” skall alltid användas tillsammans med det engelska
namnet, ex. ”the Software Engineering Student Division (IT)”.

I have updated 3 strings, looks fine to me, will the page blow up? 🔥 