### PR TITLE
Add compatibility with latest version gamma

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM ruby:2.5.1
+FROM ruby:2.5.9
 
 #installs basic needed utils
 
 RUN apt-get update && apt-get install -y \
-net-tools apt-transport-https cmake
+    net-tools apt-transport-https cmake
 
 # installs yarn which is needed to precompile
 ENV PATH=/root/.yarn/bin:$PATH
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && apt-get install -y \
-yarn
+    yarn
 #Packages
 
 RUN apt-get clean

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'nokogiri'
 
 # Caching with Redis
 gem 'redis-rails'
+gem 'redis-store', '~> 1.4.1'
 
 # Markdown for post body
 gem 'sanitize'

--- a/app/models/committee.rb
+++ b/app/models/committee.rb
@@ -11,7 +11,7 @@ class Committee < ActiveRecord::Base
   end
   def positions
     Rails.cache.fetch("groupMembers/#{self.slug}", expires_in: 30.minutes) do
-      group = open("#{Rails.configuration.account_address}/api/superGroups/#{slug}/active.json",
+      group = open("#{Rails.configuration.account_address}/api/superGroups/#{slug}/active",
       'Authorization' => "pre-shared #{Rails.application.secrets.client_credentials}")
       JSON.parse(group.read)["getFKITGroupResponse"][0]["groupMembers"].map { | i |
         [i["cid"], i["unofficialPostName"]]}.to_h

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ require 'active_resource'
 class User < ActiveResource::Base
   extend ActiveModel::Naming
   self.site = Rails.configuration.account_address
+  self.include_format_in_path = false
   self.prefix = "/api/"
   attr_writer :committees
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:2.5.9
 
 RUN apt-get update && apt-get install -y \
   #Packages

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,10 @@ services:
     ports:
       - 3306:3306
 
+  redis:
+    image: redis
+    restart: unless-stopped
+
   web:
     build:
       context: .
@@ -28,6 +32,10 @@ services:
       CLIENT_CREDENTIALS: key
       ACCOUNT_ADDRESS: http://gamma-backend:8081
       ACCOUNT_REDIRECT_ADDRESS: http://localhost:8081
+      DATABASE_NAME: it_dev
+      DATABASE_USER: it
+      DATABASE_PASSWORD: iamapassword
+      REDIS_URL: redis://redis:6379/0
 
       API_KEY: key
       DATABASE_HOST: db
@@ -60,7 +68,7 @@ services:
       - 3000:3000
 
   gamma-backend:
-    image: cthit/gamma-backend
+    image: cthit/gamma-backend:latest
     environment:
       # Default admin user name = admin
       # Default admin password  = password
@@ -86,10 +94,10 @@ services:
       SERVER_PORT: 8081
       SUCCESSFUL_LOGIN: http://localhost:3000
       CORS_ALLOWED_ORIGIN: http://localhost:3000
-      BACKEND_URI: http://localhost:8081
+      BACKEND_URI: http://localhost:8081/
       PRODUCTION: "false"
       COOKIE_DOMAIN: localhost
-      IS_MOCKING_CLIENT: "true"
+      IS_MOCKING: "true"
     depends_on:
       - gamma-redis
       - gamma-db

--- a/lib/omniauth/strategies/account.rb
+++ b/lib/omniauth/strategies/account.rb
@@ -22,7 +22,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/api/users/me.json').parsed
+        @raw_info ||= access_token.get('/api/users/me').parsed
       end
 
       def build_access_token


### PR DESCRIPTION
For some reason the latest (still 2 years old) version of gamma does not accept .json at the end of API request URLs. This causes chalmers.it to fail whenever it tries to communicate with gamma.

This PR fixes this and also makes to docker files build as they failed with the old version of ruby. 