### PR TITLE
Don't error when a post fails to fetch its committee

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -26,7 +26,12 @@ module PostsHelper
   end
 
   def link_to_committee(post)
-    link_to post.group.name, committee_path(post.group)
+    begin
+        link_to post.group.name, committee_path(post.group)
+    rescue NoMethodError
+        p "Could not find committee for post #{post.to_param}"
+        link_to "(Null)", "/"
+    end
   end
 
   def get_previous post


### PR DESCRIPTION
This makes sure that the page doesn't fail to display if a post has no committee connected to it and displays `(Null)` as the committee name. It also prints to the console when this is detected.

This is also inadvertently a fix for #309 but should not close it, since it only remediates the symptom and not the problem.